### PR TITLE
Allow suspensions within EventLoop::queue

### DIFF
--- a/src/EventLoop/Driver.php
+++ b/src/EventLoop/Driver.php
@@ -30,6 +30,18 @@ interface Driver
     public function stop(): void;
 
     /**
+     * Interrupts the event loop and continues with {main}.
+     *
+     * The driver MUST check for a set interrupt after invoking an event callback or microtask. If an interrupt exists,
+     * it must be reset, and the driver must suspend with the given callback, i.e. call \Fiber::suspend($callback);
+     *
+     * @param callable $callback Callback to run on {main} before continuing.
+     *
+     * @internal This API is only supposed to be called by the Suspension API.
+     */
+    public function interrupt(callable $callback): void;
+
+    /**
      * @return bool True if the event loop is running, false if it is stopped.
      */
     public function isRunning(): bool;

--- a/src/EventLoop/Driver/TracingDriver.php
+++ b/src/EventLoop/Driver/TracingDriver.php
@@ -36,6 +36,11 @@ final class TracingDriver implements Driver
         $this->driver->stop();
     }
 
+    public function interrupt(callable $callback): void
+    {
+        $this->driver->interrupt($callback);
+    }
+
     public function isRunning(): bool
     {
         return $this->driver->isRunning();

--- a/src/EventLoop/Suspension.php
+++ b/src/EventLoop/Suspension.php
@@ -60,7 +60,7 @@ final class Suspension
             $this->driver->queue([$this->fiber, 'throw'], $throwable);
         } else {
             // Suspend event loop fiber to {main}.
-            $this->driver->queue([\Fiber::class, 'suspend'], static fn () => throw $throwable);
+            $this->driver->interrupt(static fn () => throw $throwable);
         }
     }
 
@@ -76,7 +76,7 @@ final class Suspension
             $this->driver->queue([$this->fiber, 'resume'], $value);
         } else {
             // Suspend event loop fiber to {main}.
-            $this->driver->queue([\Fiber::class, 'suspend'], static fn () => $value);
+            $this->driver->interrupt(static fn () => $value);
         }
     }
 


### PR DESCRIPTION
This ensures it's safe to call any code within EventLoop::queue callbacks by executing callbacks in an extra fiber instead of directly from the event loop fiber.

Driver::interrupt has been added to allow the Suspension class to still suspend the event loop fiber itself to continue with {main}.