### PR TITLE
Pass interrupt as a callback to Suspension

### DIFF
--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -367,7 +367,7 @@ final class EventLoop
             self::$fiber = self::createFiber();
         }
 
-        return new Suspension(self::getDriver(), self::$fiber);
+        return self::getDriver()->createSuspension(self::$fiber);
     }
 
     /**

--- a/src/EventLoop/Driver.php
+++ b/src/EventLoop/Driver.php
@@ -30,16 +30,15 @@ interface Driver
     public function stop(): void;
 
     /**
-     * Interrupts the event loop and continues with {main}.
+     * Create an object used to suspend and resume execution, either within a fiber or from {main}.
      *
-     * The driver MUST check for a set interrupt after invoking an event callback or microtask. If an interrupt exists,
-     * it must be reset, and the driver must suspend with the given callback, i.e. call \Fiber::suspend($callback);
+     * @param \Fiber $scheduler Fiber containing the running event loop.
      *
-     * @param callable $callback Callback to run on {main} before continuing.
+     * @return Suspension
      *
      * @internal This API is only supposed to be called by the Suspension API.
      */
-    public function interrupt(callable $callback): void;
+    public function createSuspension(\Fiber $scheduler): Suspension;
 
     /**
      * @return bool True if the event loop is running, false if it is stopped.

--- a/src/EventLoop/Driver.php
+++ b/src/EventLoop/Driver.php
@@ -35,8 +35,6 @@ interface Driver
      * @param \Fiber $scheduler Fiber containing the running event loop.
      *
      * @return Suspension
-     *
-     * @internal This API is only supposed to be called by the Suspension API.
      */
     public function createSuspension(\Fiber $scheduler): Suspension;
 

--- a/src/EventLoop/Driver/TracingDriver.php
+++ b/src/EventLoop/Driver/TracingDriver.php
@@ -4,6 +4,7 @@ namespace Revolt\EventLoop\Driver;
 
 use Revolt\EventLoop\Driver;
 use Revolt\EventLoop\InvalidCallbackError;
+use Revolt\EventLoop\Suspension;
 
 final class TracingDriver implements Driver
 {
@@ -36,9 +37,9 @@ final class TracingDriver implements Driver
         $this->driver->stop();
     }
 
-    public function interrupt(callable $callback): void
+    public function createSuspension(\Fiber $scheduler): Suspension
     {
-        $this->driver->interrupt($callback);
+        return $this->driver->createSuspension($scheduler);
     }
 
     public function isRunning(): bool

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -5,6 +5,7 @@ namespace Revolt\EventLoop\Internal;
 use Revolt\EventLoop;
 use Revolt\EventLoop\Driver;
 use Revolt\EventLoop\InvalidCallbackError;
+use Revolt\EventLoop\Suspension;
 use Revolt\EventLoop\UnsupportedFeatureException;
 
 /**
@@ -46,6 +47,8 @@ abstract class AbstractDriver implements Driver
     /** @var callable|null */
     private $interrupt;
 
+    private \Closure $interruptCallback;
+
     private bool $running = false;
 
     private \stdClass $internalSuspensionMarker;
@@ -55,6 +58,7 @@ abstract class AbstractDriver implements Driver
         $this->internalSuspensionMarker = new \stdClass();
         $this->createCallbackFiber();
         $this->createQueueFiber();
+        $this->interruptCallback = \Closure::fromCallable([$this, 'interrupt']);
     }
 
     /**
@@ -104,11 +108,6 @@ abstract class AbstractDriver implements Driver
     public function stop(): void
     {
         $this->running = false;
-    }
-
-    public function interrupt(callable $callback): void
-    {
-        $this->interrupt = $callback;
     }
 
     /**
@@ -446,6 +445,11 @@ abstract class AbstractDriver implements Driver
         return $callbackId;
     }
 
+    public function createSuspension(\Fiber $scheduler): Suspension
+    {
+        return new Suspension($this, $scheduler, $this->interruptCallback);
+    }
+
     /**
      * Set a callback to be executed when an error occurs.
      *
@@ -700,6 +704,11 @@ abstract class AbstractDriver implements Driver
                 }
             }
         }
+    }
+
+    private function interrupt(callable $callback): void
+    {
+        $this->interrupt = $callback;
     }
 
     private function createCallbackFiber(): void

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -58,6 +58,7 @@ abstract class AbstractDriver implements Driver
         $this->internalSuspensionMarker = new \stdClass();
         $this->createCallbackFiber();
         $this->createQueueFiber();
+        /** @psalm-suppress InvalidArgument */
         $this->interruptCallback = \Closure::fromCallable([$this, 'interrupt']);
     }
 

--- a/src/EventLoop/Suspension.php
+++ b/src/EventLoop/Suspension.php
@@ -18,9 +18,9 @@ namespace Revolt\EventLoop;
 final class Suspension
 {
     private ?\Fiber $fiber;
-
+    private \Fiber $scheduler;
+    private Driver $driver;
     private bool $pending = false;
-
     /** @var callable */
     private $interrupt;
 
@@ -31,13 +31,15 @@ final class Suspension
      *
      * @internal
      */
-    public function __construct(
-        private Driver $driver,
-        private \Fiber $scheduler,
-        callable $interrupt
-    ) {
+    public function __construct(Driver $driver, \Fiber $scheduler, callable $interrupt)
+    {
+        $this->driver = $driver;
+        $this->scheduler = $scheduler;
         $this->interrupt = $interrupt;
         $this->fiber = \Fiber::getCurrent();
+
+        // User callbacks are always executed outside the event loop fiber, so this should always be false.
+        \assert($this->fiber !== $this->scheduler);
     }
 
     public function throw(\Throwable $throwable): void


### PR DESCRIPTION
This swaps `interrupt()` as a method on `Driver` for `createSuspension()`, which accepts the currently active event loop fiber and passes the interrupt function as a cached closure to the `Suspension` constructor.