### PR TITLE
Fiberize error handler

### DIFF
--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -395,7 +395,7 @@ final class EventLoop
 
         if ($lambda) {
             $lambda();
-            throw new \RuntimeException('Interrupt from event loop must throw an exception');
+            throw new \Error('Interrupt from event loop must throw an exception');
         }
     }
 

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -391,10 +391,11 @@ final class EventLoop
             self::$fiber = self::createFiber();
         }
 
-        if (self::$fiber->isStarted()) {
-            self::$fiber->resume();
-        } else {
-            self::$fiber->start();
+        $lambda = self::$fiber->isStarted() ? self::$fiber->resume() : self::$fiber->start();
+
+        if ($lambda) {
+            $lambda();
+            throw new \RuntimeException('Interrupt from event loop must throw an exception');
         }
     }
 

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -106,6 +106,7 @@ abstract class AbstractDriver implements Driver
             }
         } finally {
             $this->running = false;
+            $this->inFiber = false;
         }
     }
 
@@ -118,7 +119,6 @@ abstract class AbstractDriver implements Driver
     public function stop(): void
     {
         $this->running = false;
-        $this->inFiber = false;
     }
 
     /**

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -89,6 +89,10 @@ abstract class AbstractDriver implements Driver
 
         try {
             while ($this->running) {
+                if ($this->interrupt) {
+                    $this->invokeInterrupt();
+                }
+
                 $this->invokeMicrotasks();
 
                 if ($this->isEmpty()) {
@@ -615,7 +619,8 @@ abstract class AbstractDriver implements Driver
     protected function error(\Throwable $exception): void
     {
         if ($this->errorHandler === null) {
-            throw $exception;
+            $this->interrupt = static fn () => throw $exception;
+            return;
         }
 
         $fiber = new \Fiber(function (callable $errorHandler, \Throwable $exception): void {

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -621,10 +621,8 @@ abstract class AbstractDriver implements Driver
      */
     protected function error(\Throwable $exception): void
     {
-        \assert($this->interrupt === null);
-
         if ($this->errorHandler === null) {
-            $this->interrupt = static fn () => throw $exception;
+            $this->setInterrupt(static fn () => throw $exception);
             return;
         }
 

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -730,7 +730,7 @@ abstract class AbstractDriver implements Driver
 
         if (!$this->inFiber) {
             $interrupt();
-            throw new \RuntimeException('Interrupt must throw if not executing in a fiber');
+            throw new \Error('Interrupt must throw if not executing in a fiber');
         }
 
         \Fiber::suspend($interrupt);

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -60,8 +60,7 @@ abstract class AbstractDriver implements Driver
         $this->internalSuspensionMarker = new \stdClass();
         $this->createCallbackFiber();
         $this->createQueueFiber();
-        /** @psalm-suppress InvalidArgument */
-        $this->interruptCallback = \Closure::fromCallable([$this, 'interrupt']);
+        $this->interruptCallback = fn (callable $interrupt) => $this->interrupt = $interrupt;
     }
 
     /**
@@ -623,7 +622,7 @@ abstract class AbstractDriver implements Driver
             try {
                 $errorHandler($exception);
             } catch (\Throwable $exception) {
-                $this->interrupt(static fn () => throw $exception);
+                $this->interrupt = static fn () => throw $exception;
             }
         });
 
@@ -726,11 +725,6 @@ abstract class AbstractDriver implements Driver
         }
 
         \Fiber::suspend($interrupt);
-    }
-
-    private function interrupt(callable $callback): void
-    {
-        $this->interrupt = $callback;
     }
 
     private function createCallbackFiber(): void

--- a/src/EventLoop/Suspension.php
+++ b/src/EventLoop/Suspension.php
@@ -21,6 +21,7 @@ final class Suspension
     private \Fiber $scheduler;
     private Driver $driver;
     private bool $pending = false;
+    private ?\Error $error = null;
     /** @var callable */
     private $interrupt;
 
@@ -45,7 +46,7 @@ final class Suspension
     public function throw(\Throwable $throwable): void
     {
         if (!$this->pending) {
-            throw new \Error('Must call throw() before calling resume()');
+            throw $this->error ?? new \Error('Must call suspend() before calling throw()');
         }
 
         $this->pending = false;
@@ -61,7 +62,7 @@ final class Suspension
     public function resume(mixed $value): void
     {
         if (!$this->pending) {
-            throw new \Error('Must call suspend() before calling resume()');
+            throw $this->error ?? new \Error('Must call suspend() before calling resume()');
         }
 
         $this->pending = false;
@@ -88,7 +89,13 @@ final class Suspension
 
         // Awaiting from within a fiber.
         if ($this->fiber) {
-            return \Fiber::suspend();
+            try {
+                return \Fiber::suspend();
+            } catch (\FiberError $exception) {
+                $this->pending = false;
+                $this->error = $exception;
+                throw $exception;
+            }
         }
 
         // Awaiting from {main}.

--- a/src/EventLoop/Suspension.php
+++ b/src/EventLoop/Suspension.php
@@ -21,7 +21,7 @@ final class Suspension
     private \Fiber $scheduler;
     private Driver $driver;
     private bool $pending = false;
-    private ?\Error $error = null;
+    private ?\FiberError $error = null;
     /** @var callable */
     private $interrupt;
 


### PR DESCRIPTION
This fixes two issues:
1) The loop error handler may now suspend similar to any other loop callback. I didn't reuse a fiber for this purpose as the loop error handler should be called infrequently.
2) If `Suspension::suspend()` is called in a context where fiber switching is not allowed (i.e., with a `__destruct` call), an exception was thrown but the state of `Suspension` was invalid. The exception thrown may be caught and handled, but the event for the suspension would still be pending, resuming the fiber at a later time incorrectly. This PR catches the exception, fixes the state of `Suspension`, then rethrows the exception from `suspend()` as well as any subsequent calls to `resume()` or `throw()`.

@kelunik @bwoebi This makes the errors we were seeing very obvious. The instance of `FiberError` has a stack trace directly to the call to `Suspension::suspend()` that was within a destructor that needed to be fixed.