### PR TITLE
fix(driver): use `mixed` as a return type for `EventDriver::getHandle()` and `EvDriver::getHandle()`

### DIFF
--- a/src/EventLoop/Driver/EvDriver.php
+++ b/src/EventLoop/Driver/EvDriver.php
@@ -146,7 +146,7 @@ final class EvDriver extends AbstractDriver
     /**
      * {@inheritdoc}
      */
-    public function getHandle(): \EvLoop
+    public function getHandle(): mixed
     {
         return $this->handle;
     }

--- a/src/EventLoop/Driver/EventDriver.php
+++ b/src/EventLoop/Driver/EventDriver.php
@@ -147,7 +147,7 @@ final class EventDriver extends AbstractDriver
     /**
      * {@inheritdoc}
      */
-    public function getHandle(): \EventBase
+    public function getHandle(): mixed
     {
         return $this->handle;
     }


### PR DESCRIPTION
when one of these extensions is not installed, and `isSupported()` gets called from the driver factory, you will receive the following error:

```shell
> php test.php
PHP Fatal error:  Could not check compatibility between Revolt\EventLoop\Driver\EventDriver::getHandle(): EventBase and Revolt\EventLoop\Driver::getHandle(): mixed, because class EventBase is not available in /home/azjezz/Projects/php-standard-library/vendor/revolt/event-loop/src/EventLoop/Driver/EventDriver.php on line 150

Fatal error: Could not check compatibility between Revolt\EventLoop\Driver\EventDriver::getHandle(): EventBase and Revolt\EventLoop\Driver::getHandle(): mixed, because class EventBase is not available in /home/azjezz/Projects/php-standard-library/vendor/revolt/event-loop/src/EventLoop/Driver/EventDriver.php on line 150
```

This is somehow PHP's fault as regardless if the type `T` exist or not, compatibility check for return type from `mixed` to `T` should pass, but fixing it here is easier :)

