### PR TITLE
Default $value to null in Suspension::resume

### DIFF
--- a/examples/http-client-suspension.php
+++ b/examples/http-client-suspension.php
@@ -30,7 +30,7 @@ function fetch(string $url): string
     \stream_set_blocking($stream, false);
 
     // wait for connection success/error
-    $watcher = EventLoop::onWritable($stream, fn () => $suspension->resume(null));
+    $watcher = EventLoop::onWritable($stream, fn () => $suspension->resume());
     $suspension->suspend();
     EventLoop::cancel($watcher);
 
@@ -40,7 +40,7 @@ function fetch(string $url): string
     $buffer = '';
 
     // wait for HTTP response
-    $watcher = EventLoop::onReadable($stream, fn () => $suspension->resume(null));
+    $watcher = EventLoop::onReadable($stream, fn () => $suspension->resume());
 
     do {
         $suspension->suspend();

--- a/examples/invalid-callback-return.php
+++ b/examples/invalid-callback-return.php
@@ -14,7 +14,7 @@ EventLoop::onSignal(\SIGINT, function (string $watcherId) use ($suspension) {
 
     print "Caught SIGINT, exiting..." . PHP_EOL;
 
-    $suspension->resume(null);
+    $suspension->resume();
 
     return new \stdClass();
 });

--- a/examples/stdin-timeout.php
+++ b/examples/stdin-timeout.php
@@ -21,10 +21,10 @@ $readWatcher = EventLoop::onReadable(STDIN, function ($watcherId, $stream) use (
 
     print "Read " . \strlen($chunk) . " bytes" . PHP_EOL;
 
-    $suspension->resume(null);
+    $suspension->resume();
 });
 
-$timeoutWatcher = EventLoop::delay(5000, fn () => $suspension->resume(null));
+$timeoutWatcher = EventLoop::delay(5000, fn () => $suspension->resume());
 
 $suspension->suspend();
 

--- a/examples/stdin.php
+++ b/examples/stdin.php
@@ -21,7 +21,7 @@ EventLoop::onReadable(STDIN, function ($watcherId, $stream) use ($suspension) {
 
     print "Read " . \strlen($chunk) . " bytes" . PHP_EOL;
 
-    $suspension->resume(null);
+    $suspension->resume();
 });
 
 $suspension->suspend();

--- a/examples/timers.php
+++ b/examples/timers.php
@@ -15,7 +15,7 @@ EventLoop::delay(5, function () use ($suspension, $repeatWatcher) {
     print "++ Executing watcher created by Loop::delay()" . PHP_EOL;
 
     EventLoop::cancel($repeatWatcher);
-    $suspension->resume(null);
+    $suspension->resume();
 
     print "++ Executed after script ended" . PHP_EOL;
 });

--- a/src/EventLoop/Suspension.php
+++ b/src/EventLoop/Suspension.php
@@ -59,7 +59,7 @@ final class Suspension
         }
     }
 
-    public function resume(mixed $value): void
+    public function resume(mixed $value = null): void
     {
         if (!$this->pending) {
             throw $this->error ?? new \Error('Must call suspend() before calling resume()');

--- a/test/EventLoopTest.php
+++ b/test/EventLoopTest.php
@@ -38,7 +38,7 @@ class EventLoopTest extends TestCase
             EventLoop::cancel($callbackId);
             $count++;
 
-            $suspension->resume(null);
+            $suspension->resume();
         });
 
         $suspension->suspend();
@@ -56,7 +56,7 @@ class EventLoopTest extends TestCase
             EventLoop::cancel($callbackId);
             $count++;
 
-            $suspension->resume(null);
+            $suspension->resume();
         });
 
         $suspension->suspend();


### PR DESCRIPTION
Often there's no need for a value, and we just want to resume at the suspension point.

Fixes #11.