### PR TITLE
Use \Closure instead of callable

### DIFF
--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -90,7 +90,7 @@ final class EventLoop
      * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
      * right before the next tick. Deferred callbacks MUST NOT be called in the tick they were enabled.
      *
-     * @param \Closure $closure The callback to defer. The `$callbackId` will be
+     * @param \Closure(string):void $closure The callback to defer. The `$callbackId` will be
      *     invalidated before the callback invocation.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
@@ -109,9 +109,9 @@ final class EventLoop
      * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
-     * @param float    $delay The amount of time, in seconds, to delay the execution for.
-     * @param \Closure $closure The callback to delay. The `$callbackId` will be invalidated before
-     *     the callback invocation.
+     * @param float $delay The amount of time, in seconds, to delay the execution for.
+     * @param \Closure(string):void $closure The callback to delay. The `$callbackId` will be invalidated
+     *     before the callback invocation.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
@@ -131,7 +131,7 @@ final class EventLoop
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
      * @param float $interval The time interval, in seconds, to wait between executions.
-     * @param \Closure $closure The callback to repeat.
+     * @param \Closure(string):void $closure The callback to repeat.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
@@ -154,7 +154,7 @@ final class EventLoop
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
      * @param resource|object $stream The stream to monitor.
-     * @param \Closure $callback The callback to execute.
+     * @param \Closure(string, resource|object):void $callback The callback to execute.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
@@ -177,7 +177,7 @@ final class EventLoop
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
      * @param resource|object $stream The stream to monitor.
-     * @param \Closure $closure The callback to execute.
+     * @param \Closure(string, resource|object):void $closure The callback to execute.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
@@ -198,16 +198,16 @@ final class EventLoop
      * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
-     * @param int $signo The signal number to monitor.
-     * @param \Closure $closure The callback to execute.
+     * @param int $signal The signal number to monitor.
+     * @param \Closure(string, int):void $closure The callback to execute.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      *
      * @throws UnsupportedFeatureException If signal handling is not supported.
      */
-    public static function onSignal(int $signo, \Closure $closure): string
+    public static function onSignal(int $signal, \Closure $closure): string
     {
-        return self::getDriver()->onSignal($signo, $closure);
+        return self::getDriver()->onSignal($signal, $closure);
     }
 
     /**
@@ -299,9 +299,9 @@ final class EventLoop
      *
      * Subsequent calls to this method will overwrite the previous handler.
      *
-     * @param \Closure|null $closure The callback to execute. `null` will clear the current handler.
+     * @param (\Closure(\Throwable):void)|null $closure The callback to execute. `null` will clear the current handler.
      *
-     * @return \Closure|null The previous handler, `null` if there was none.
+     * @return (\Closure(\Throwable):void)|null The previous handler, `null` if there was none.
      */
     public static function setErrorHandler(\Closure $closure = null): ?\Closure
     {

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -67,37 +67,37 @@ final class EventLoop
     /**
      * Queue a microtask.
      *
-     * The queued callable MUST be executed immediately once the event loop gains control. Order of queueing MUST be
+     * The queued callback MUST be executed immediately once the event loop gains control. Order of queueing MUST be
      * preserved when executing the callbacks. Recursive scheduling can thus result in infinite loops, use with care.
      *
      * Does NOT create an event callback, thus CAN NOT be marked as disabled or unreferenced.
      * Use {@see EventLoop::defer()} if you need these features.
      *
-     * @param callable $callback The callback to queue.
+     * @param \Closure $closure The callback to queue.
      * @param mixed    ...$args The callback arguments.
      */
-    public static function queue(callable $callback, mixed ...$args): void
+    public static function queue(\Closure $closure, mixed ...$args): void
     {
-        self::getDriver()->queue($callback, ...$args);
+        self::getDriver()->queue($closure, ...$args);
     }
 
     /**
      * Defer the execution of a callback.
      *
-     * The deferred callable MUST be executed before any other type of callback in a tick. Order of enabling MUST be
+     * The deferred callback MUST be executed before any other type of callback in a tick. Order of enabling MUST be
      * preserved when executing the callbacks.
      *
      * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
      * right before the next tick. Deferred callbacks MUST NOT be called in the tick they were enabled.
      *
-     * @param callable(string) $callback The callback to defer. The `$callbackId` will be
+     * @param \Closure $closure The callback to defer. The `$callbackId` will be
      *     invalidated before the callback invocation.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
-    public static function defer(callable $callback): string
+    public static function defer(\Closure $closure): string
     {
-        return self::getDriver()->defer($callback);
+        return self::getDriver()->defer($closure);
     }
 
     /**
@@ -109,15 +109,15 @@ final class EventLoop
      * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
-     * @param float $delay The amount of time, in seconds, to delay the execution for.
-     * @param callable(string) $callback The callback to delay. The `$callbackId` will be invalidated before
+     * @param float    $delay The amount of time, in seconds, to delay the execution for.
+     * @param \Closure $closure The callback to delay. The `$callbackId` will be invalidated before
      *     the callback invocation.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
-    public static function delay(float $delay, callable $callback): string
+    public static function delay(float $delay, \Closure $closure): string
     {
-        return self::getDriver()->delay($delay, $callback);
+        return self::getDriver()->delay($delay, $closure);
     }
 
     /**
@@ -131,13 +131,13 @@ final class EventLoop
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
      * @param float $interval The time interval, in seconds, to wait between executions.
-     * @param callable(string) $callback The callback to repeat.
+     * @param \Closure $closure The callback to repeat.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
-    public static function repeat(float $interval, callable $callback): string
+    public static function repeat(float $interval, \Closure $closure): string
     {
-        return self::getDriver()->repeat($interval, $callback);
+        return self::getDriver()->repeat($interval, $closure);
     }
 
     /**
@@ -154,13 +154,13 @@ final class EventLoop
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
      * @param resource|object $stream The stream to monitor.
-     * @param callable(string, resource|object) $callback The callback to execute.
+     * @param \Closure $callback The callback to execute.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
-    public static function onReadable(mixed $stream, callable $callback): string
+    public static function onReadable(mixed $stream, \Closure $closure): string
     {
-        return self::getDriver()->onReadable($stream, $callback);
+        return self::getDriver()->onReadable($stream, $closure);
     }
 
     /**
@@ -177,13 +177,13 @@ final class EventLoop
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
      * @param resource|object $stream The stream to monitor.
-     * @param callable(string, resource|object) $callback The callback to execute.
+     * @param \Closure $closure The callback to execute.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
-    public static function onWritable(mixed $stream, callable $callback): string
+    public static function onWritable(mixed $stream, \Closure $closure): string
     {
-        return self::getDriver()->onWritable($stream, $callback);
+        return self::getDriver()->onWritable($stream, $closure);
     }
 
     /**
@@ -199,15 +199,15 @@ final class EventLoop
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
      * @param int $signo The signal number to monitor.
-     * @param callable(string, int) $callback The callback to execute.
+     * @param \Closure $closure The callback to execute.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      *
      * @throws UnsupportedFeatureException If signal handling is not supported.
      */
-    public static function onSignal(int $signo, callable $callback): string
+    public static function onSignal(int $signo, \Closure $closure): string
     {
-        return self::getDriver()->onSignal($signo, $callback);
+        return self::getDriver()->onSignal($signo, $closure);
     }
 
     /**
@@ -299,14 +299,13 @@ final class EventLoop
      *
      * Subsequent calls to this method will overwrite the previous handler.
      *
-     * @param callable(\Throwable)|null $callback The callback to execute. `null` will clear the
-     *     current handler.
+     * @param \Closure|null $closure The callback to execute. `null` will clear the current handler.
      *
-     * @return callable(\Throwable)|null The previous handler, `null` if there was none.
+     * @return \Closure|null The previous handler, `null` if there was none.
      */
-    public static function setErrorHandler(callable $callback = null): ?callable
+    public static function setErrorHandler(\Closure $closure = null): ?\Closure
     {
-        return self::getDriver()->setErrorHandler($callback);
+        return self::getDriver()->setErrorHandler($closure);
     }
 
     /**

--- a/src/EventLoop/Driver.php
+++ b/src/EventLoop/Driver.php
@@ -44,32 +44,32 @@ interface Driver
     /**
      * Queue a microtask.
      *
-     * The queued callable MUST be executed immediately once the event loop gains control. Order of queueing MUST be
+     * The queued callback MUST be executed immediately once the event loop gains control. Order of queueing MUST be
      * preserved when executing the callbacks. Recursive scheduling can thus result in infinite loops, use with care.
      *
      * Does NOT create an event callback, thus CAN NOT be marked as disabled or unreferenced.
      * Use {@see EventLoop::defer()} if you need these features.
      *
-     * @param callable $callback The callback to queue.
+     * @param \Closure $closure The callback to queue.
      * @param mixed    ...$args The callback arguments.
      */
-    public function queue(callable $callback, mixed ...$args): void;
+    public function queue(\Closure $closure, mixed ...$args): void;
 
     /**
      * Defer the execution of a callback.
      *
-     * The deferred callable MUST be executed before any other type of callback in a tick. Order of enabling MUST be
+     * The deferred callback MUST be executed before any other type of callback in a tick. Order of enabling MUST be
      * preserved when executing the callbacks.
      *
      * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
-     * @param callable(string):void $callback The callback to defer. The `$callbackId` will be
+     * @param \Closure $closure The callback to defer. The `$callbackId` will be
      *                    invalidated before the callback invocation.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
-    public function defer(callable $callback): string;
+    public function defer(\Closure $closure): string;
 
     /**
      * Delay the execution of a callback.
@@ -80,13 +80,13 @@ interface Driver
      * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
-     * @param float   $delay The amount of time, in seconds, to delay the execution for.
-     * @param callable(string):void $callback The callback to delay. The `$callbackId` will be
-     *                     invalidated before the callback invocation.
+     * @param float    $delay The amount of time, in seconds, to delay the execution for.
+     * @param \Closure $closure The callback to delay. The `$callbackId` will be invalidated before the callback
+     *     invocation.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
-    public function delay(float $delay, callable $callback): string;
+    public function delay(float $delay, \Closure $closure): string;
 
     /**
      * Repeatedly execute a callback.
@@ -98,12 +98,12 @@ interface Driver
      * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
-     * @param float   $interval The time interval, in seconds, to wait between executions.
-     * @param callable(string):void $callback The callback to repeat.
+     * @param float    $interval The time interval, in seconds, to wait between executions.
+     * @param \Closure $closure The callback to repeat.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
-    public function repeat(float $interval, callable $callback): string;
+    public function repeat(float $interval, \Closure $closure): string;
 
     /**
      * Execute a callback when a stream resource becomes readable or is closed for reading.
@@ -119,11 +119,11 @@ interface Driver
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
      * @param resource|object $stream The stream to monitor.
-     * @param callable(string, resource|object):void $callback The callback to execute.
+     * @param \Closure        $closure The callback to execute.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
-    public function onReadable(mixed $stream, callable $callback): string;
+    public function onReadable(mixed $stream, \Closure $closure): string;
 
     /**
      * Execute a callback when a stream resource becomes writable or is closed for writing.
@@ -139,11 +139,11 @@ interface Driver
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
      * @param resource|object $stream The stream to monitor.
-     * @param callable(string, resource|object):void $callback The callback to execute.
+     * @param \Closure        $closure The callback to execute.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
-    public function onWritable(mixed $stream, callable $callback): string;
+    public function onWritable(mixed $stream, \Closure $closure): string;
 
     /**
      * Execute a callback when a signal is received.
@@ -157,20 +157,20 @@ interface Driver
      * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
-     * @param int   $signo The signal number to monitor.
-     * @param callable(string, int):void $callback The callback to execute.
+     * @param int      $signo The signal number to monitor.
+     * @param \Closure $closure The callback to execute.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      *
      * @throws UnsupportedFeatureException If signal handling is not supported.
      */
-    public function onSignal(int $signo, callable $callback): string;
+    public function onSignal(int $signo, \Closure $closure): string;
 
     /**
      * Enable a callback to be active starting in the next tick.
      *
-     * Callbacks MUST immediately be marked as enabled, but only be activated (i.e. callbacks can be called) right before
-     * the next tick. Callbacks MUST NOT be called in the tick they were enabled.
+     * Callbacks MUST immediately be marked as enabled, but only be activated (i.e. callbacks can be called) right
+     * before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
      * @param string $callbackId The callback identifier.
      *
@@ -240,12 +240,11 @@ interface Driver
      *
      * Subsequent calls to this method will overwrite the previous handler.
      *
-     * @param (callable(\Throwable):void)|null $callback The callback to execute. `null` will clear the
-     *     current handler.
+     * @param \Closure|null $closure The callback to execute. `null` will clear the current handler.
      *
-     * @return (callable(\Throwable):void)|null The previous handler, `null` if there was none.
+     * @return \Closure|null The previous handler, `null` if there was none.
      */
-    public function setErrorHandler(callable $callback = null): ?callable;
+    public function setErrorHandler(?\Closure $closure = null): ?callable;
 
     /**
      * Get the underlying loop handle.

--- a/src/EventLoop/Driver.php
+++ b/src/EventLoop/Driver.php
@@ -64,8 +64,8 @@ interface Driver
      * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
-     * @param \Closure $closure The callback to defer. The `$callbackId` will be
-     *                    invalidated before the callback invocation.
+     * @param \Closure(string):void $closure The callback to defer. The `$callbackId` will be invalidated before the
+     *     callback invocation.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
@@ -80,9 +80,9 @@ interface Driver
      * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
-     * @param float    $delay The amount of time, in seconds, to delay the execution for.
-     * @param \Closure $closure The callback to delay. The `$callbackId` will be invalidated before the callback
-     *     invocation.
+     * @param float $delay The amount of time, in seconds, to delay the execution for.
+     * @param \Closure(string):void $closure The callback to delay. The `$callbackId` will be invalidated before the
+     *     callback invocation.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
@@ -98,8 +98,8 @@ interface Driver
      * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
-     * @param float    $interval The time interval, in seconds, to wait between executions.
-     * @param \Closure $closure The callback to repeat.
+     * @param float $interval The time interval, in seconds, to wait between executions.
+     * @param \Closure(string):void $closure The callback to repeat.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
@@ -119,7 +119,7 @@ interface Driver
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
      * @param resource|object $stream The stream to monitor.
-     * @param \Closure        $closure The callback to execute.
+     * @param \Closure(string, resource|object):void $closure The callback to execute.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
@@ -139,7 +139,7 @@ interface Driver
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
      * @param resource|object $stream The stream to monitor.
-     * @param \Closure        $closure The callback to execute.
+     * @param \Closure(string, resource|object):void $closure The callback to execute.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
@@ -157,14 +157,14 @@ interface Driver
      * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
-     * @param int      $signo The signal number to monitor.
-     * @param \Closure $closure The callback to execute.
+     * @param int $signal The signal number to monitor.
+     * @param \Closure(string, int):void $closure The callback to execute.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      *
      * @throws UnsupportedFeatureException If signal handling is not supported.
      */
-    public function onSignal(int $signo, \Closure $closure): string;
+    public function onSignal(int $signal, \Closure $closure): string;
 
     /**
      * Enable a callback to be active starting in the next tick.
@@ -240,9 +240,9 @@ interface Driver
      *
      * Subsequent calls to this method will overwrite the previous handler.
      *
-     * @param \Closure|null $closure The callback to execute. `null` will clear the current handler.
+     * @param (\Closure(\Throwable):void)|null $closure The callback to execute. `null` will clear the current handler.
      *
-     * @return \Closure|null The previous handler, `null` if there was none.
+     * @return (\Closure(\Throwable):void)|null The previous handler, `null` if there was none.
      */
     public function setErrorHandler(?\Closure $closure = null): ?callable;
 

--- a/src/EventLoop/Driver/StreamSelectDriver.php
+++ b/src/EventLoop/Driver/StreamSelectDriver.php
@@ -89,13 +89,13 @@ final class StreamSelectDriver extends AbstractDriver
      *
      * @throws UnsupportedFeatureException If the pcntl extension is not available.
      */
-    public function onSignal(int $signo, callable $callback): string
+    public function onSignal(int $signo, \Closure $closure): string
     {
         if (!$this->signalHandling) {
             throw new UnsupportedFeatureException("Signal handling requires the pcntl extension");
         }
 
-        return parent::onSignal($signo, $callback);
+        return parent::onSignal($signo, $closure);
     }
 
     /**

--- a/src/EventLoop/Driver/StreamSelectDriver.php
+++ b/src/EventLoop/Driver/StreamSelectDriver.php
@@ -89,13 +89,13 @@ final class StreamSelectDriver extends AbstractDriver
      *
      * @throws UnsupportedFeatureException If the pcntl extension is not available.
      */
-    public function onSignal(int $signo, \Closure $closure): string
+    public function onSignal(int $signal, \Closure $closure): string
     {
         if (!$this->signalHandling) {
             throw new UnsupportedFeatureException("Signal handling requires the pcntl extension");
         }
 
-        return parent::onSignal($signo, $closure);
+        return parent::onSignal($signal, $closure);
     }
 
     /**

--- a/src/EventLoop/Driver/TracingDriver.php
+++ b/src/EventLoop/Driver/TracingDriver.php
@@ -47,11 +47,11 @@ final class TracingDriver implements Driver
         return $this->driver->isRunning();
     }
 
-    public function defer(callable $callback): string
+    public function defer(\Closure $closure): string
     {
-        $id = $this->driver->defer(function (...$args) use ($callback) {
+        $id = $this->driver->defer(function (...$args) use ($closure) {
             $this->cancel($args[0]);
-            return $callback(...$args);
+            return $closure(...$args);
         });
 
         $this->creationTraces[$id] = $this->formatStacktrace(\debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS));
@@ -60,11 +60,11 @@ final class TracingDriver implements Driver
         return $id;
     }
 
-    public function delay(float $delay, callable $callback): string
+    public function delay(float $delay, \Closure $closure): string
     {
-        $id = $this->driver->delay($delay, function (...$args) use ($callback) {
+        $id = $this->driver->delay($delay, function (...$args) use ($closure) {
             $this->cancel($args[0]);
-            return $callback(...$args);
+            return $closure(...$args);
         });
 
         $this->creationTraces[$id] = $this->formatStacktrace(\debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS));
@@ -73,9 +73,9 @@ final class TracingDriver implements Driver
         return $id;
     }
 
-    public function repeat(float $interval, callable $callback): string
+    public function repeat(float $interval, \Closure $closure): string
     {
-        $id = $this->driver->repeat($interval, $callback);
+        $id = $this->driver->repeat($interval, $closure);
 
         $this->creationTraces[$id] = $this->formatStacktrace(\debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS));
         $this->enabledCallbacks[$id] = true;
@@ -83,9 +83,9 @@ final class TracingDriver implements Driver
         return $id;
     }
 
-    public function onReadable(mixed $stream, callable $callback): string
+    public function onReadable(mixed $stream, \Closure $closure): string
     {
-        $id = $this->driver->onReadable($stream, $callback);
+        $id = $this->driver->onReadable($stream, $closure);
 
         $this->creationTraces[$id] = $this->formatStacktrace(\debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS));
         $this->enabledCallbacks[$id] = true;
@@ -93,9 +93,9 @@ final class TracingDriver implements Driver
         return $id;
     }
 
-    public function onWritable(mixed $stream, callable $callback): string
+    public function onWritable(mixed $stream, \Closure $closure): string
     {
-        $id = $this->driver->onWritable($stream, $callback);
+        $id = $this->driver->onWritable($stream, $closure);
 
         $this->creationTraces[$id] = $this->formatStacktrace(\debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS));
         $this->enabledCallbacks[$id] = true;
@@ -103,9 +103,9 @@ final class TracingDriver implements Driver
         return $id;
     }
 
-    public function onSignal(int $signo, callable $callback): string
+    public function onSignal(int $signo, \Closure $closure): string
     {
-        $id = $this->driver->onSignal($signo, $callback);
+        $id = $this->driver->onSignal($signo, $closure);
 
         $this->creationTraces[$id] = $this->formatStacktrace(\debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS));
         $this->enabledCallbacks[$id] = true;
@@ -170,9 +170,9 @@ final class TracingDriver implements Driver
         return $callbackId;
     }
 
-    public function setErrorHandler(callable $callback = null): ?callable
+    public function setErrorHandler(\Closure $closure = null): ?callable
     {
-        return $this->driver->setErrorHandler($callback);
+        return $this->driver->setErrorHandler($closure);
     }
 
     /** @inheritdoc */
@@ -208,9 +208,9 @@ final class TracingDriver implements Driver
         return $this->driver->__debugInfo();
     }
 
-    public function queue(callable $callback, mixed ...$args): void
+    public function queue(\Closure $closure, mixed ...$args): void
     {
-        $this->driver->queue($callback, ...$args);
+        $this->driver->queue($closure, ...$args);
     }
 
     private function getCreationTrace(string $callbackId): string

--- a/src/EventLoop/Driver/TracingDriver.php
+++ b/src/EventLoop/Driver/TracingDriver.php
@@ -103,9 +103,9 @@ final class TracingDriver implements Driver
         return $id;
     }
 
-    public function onSignal(int $signo, \Closure $closure): string
+    public function onSignal(int $signal, \Closure $closure): string
     {
-        $id = $this->driver->onSignal($signo, $closure);
+        $id = $this->driver->onSignal($signal, $closure);
 
         $this->creationTraces[$id] = $this->formatStacktrace(\debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS));
         $this->enabledCallbacks[$id] = true;

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -103,21 +103,6 @@ abstract class AbstractDriver implements Driver
         };
     }
 
-    /**
-     * Run the event loop.
-     *
-     * One iteration of the loop is called one "tick". A tick covers the following steps:
-     *
-     *  1. Activate callbacks created / enabled in the last tick / before `run()`.
-     *  2. Execute all enabled deferred callbacks.
-     *  3. Execute all due timer, pending signal and actionable stream callbacks, each only once per tick.
-     *
-     * The loop MUST continue to run until it is either stopped explicitly, no referenced callbacks exist anymore, or an
-     * exception is thrown that cannot be handled. Exceptions that cannot be handled are exceptions thrown from an
-     * error handler or exceptions that would be passed to an error handler but none exists to handle them.
-     *
-     * @throw \Error Thrown if the event loop is already running.
-     */
     public function run(): void
     {
         if ($this->fiber->isRunning()) {
@@ -141,55 +126,21 @@ abstract class AbstractDriver implements Driver
         }
     }
 
-    /**
-     * Stop the event loop.
-     *
-     * When an event loop is stopped, it continues with its current tick and exits the loop afterwards. Multiple calls
-     * to stop MUST be ignored and MUST NOT raise an exception.
-     */
     public function stop(): void
     {
         $this->stopped = true;
     }
 
-    /**
-     * @return bool True if the event loop is running, false if it is stopped.
-     */
     public function isRunning(): bool
     {
         return $this->fiber->isRunning() || $this->fiber->isSuspended();
     }
 
-    /**
-     * Queue a microtask.
-     *
-     * The queued callback MUST be executed immediately once the event loop gains control. Order of queueing MUST be
-     * preserved when executing the callbacks. Recursive scheduling can thus result in infinite loops, use with care.
-     *
-     * Does NOT create an event callback, thus CAN NOT be marked as disabled or unreferenced.
-     * Use {@see EventLoop::defer()} if you need these features.
-     *
-     * @param \Closure $closure The callback to queue.
-     * @param mixed    ...$args The callback arguments.
-     */
     public function queue(\Closure $closure, mixed ...$args): void
     {
         $this->microQueue[] = [$closure, $args];
     }
 
-    /**
-     * Defer the execution of a callback.
-     *
-     * The deferred callback MUST be executed before any other type of callback in a tick. Order of enabling MUST be
-     * preserved when executing the callbacks.
-     *
-     * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
-     * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
-     *
-     * @param \Closure $closure The callback to defer. The `$callbackId` will be invalidated before the callback call.
-     *
-     * @return string A unique identifier that can be used to cancel, enable or disable the callback.
-     */
     public function defer(\Closure $closure): string
     {
         $deferCallback = new DeferCallback($this->nextId++, $closure);
@@ -200,21 +151,6 @@ abstract class AbstractDriver implements Driver
         return $deferCallback->id;
     }
 
-    /**
-     * Delay the execution of a callback.
-     *
-     * The delay is a minimum and approximate, accuracy is not guaranteed. Order of calls MUST be determined by which
-     * timers expire first, but timers with the same expiration time MAY be executed in any order.
-     *
-     * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
-     * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
-     *
-     * @param float    $delay The amount of time, in seconds, to delay the execution for.
-     * @param \Closure $closure The callback to delay. The `$callbackId` will be invalidated before the callback
-     *     invocation.
-     *
-     * @return string A unique identifier that can be used to cancel, enable or disable the callback.
-     */
     public function delay(float $delay, \Closure $closure): string
     {
         if ($delay < 0) {
@@ -229,21 +165,6 @@ abstract class AbstractDriver implements Driver
         return $timerCallback->id;
     }
 
-    /**
-     * Repeatedly execute a callback.
-     *
-     * The interval between executions is a minimum and approximate, accuracy is not guaranteed. Order of calls MUST be
-     * determined by which timers expire first, but timers with the same expiration time MAY be executed in any order.
-     * The first execution is scheduled after the first interval period.
-     *
-     * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
-     * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
-     *
-     * @param float    $interval The time interval, in seconds, to wait between executions.
-     * @param \Closure $closure The callback to repeat.
-     *
-     * @return string A unique identifier that can be used to cancel, enable or disable the callback.
-     */
     public function repeat(float $interval, \Closure $closure): string
     {
         if ($interval < 0) {
@@ -258,24 +179,6 @@ abstract class AbstractDriver implements Driver
         return $timerCallback->id;
     }
 
-    /**
-     * Execute a callback when a stream resource becomes readable or is closed for reading.
-     *
-     * Warning: Closing resources locally, e.g. with `fclose`, might not invoke the callback. Be sure to `cancel` the
-     * callback when closing the resource locally. Drivers MAY choose to notify the user if there are callbacks on
-     * invalid resources, but are not required to, due to the high performance impact. Callbacks on closed resources are
-     * therefore undefined behavior.
-     *
-     * Multiple callbacks on the same stream MAY be executed in any order.
-     *
-     * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
-     * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
-     *
-     * @param resource|object $stream The stream to monitor.
-     * @param \Closure        $closure The callback to execute.
-     *
-     * @return string A unique identifier that can be used to cancel, enable or disable the callback.
-     */
     public function onReadable(mixed $stream, \Closure $closure): string
     {
         $streamCallback = new StreamReadableCallback($this->nextId++, $closure, $stream);
@@ -286,24 +189,6 @@ abstract class AbstractDriver implements Driver
         return $streamCallback->id;
     }
 
-    /**
-     * Execute a callback when a stream resource becomes writable or is closed for writing.
-     *
-     * Warning: Closing resources locally, e.g. with `fclose`, might not invoke the callback. Be sure to `cancel` the
-     * callback when closing the resource locally. Drivers MAY choose to notify the user if there are callbacks on
-     * invalid resources, but are not required to, due to the high performance impact. Callbacks on closed resources are
-     * therefore undefined behavior.
-     *
-     * Multiple callbacks on the same stream MAY be executed in any order.
-     *
-     * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
-     * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
-     *
-     * @param resource|object $stream The stream to monitor.
-     * @param \Closure        $closure The callback to execute.
-     *
-     * @return string A unique identifier that can be used to cancel, enable or disable the callback.
-     */
     public function onWritable($stream, \Closure $closure): string
     {
         $streamCallback = new StreamWritableCallback($this->nextId++, $closure, $stream);
@@ -314,28 +199,9 @@ abstract class AbstractDriver implements Driver
         return $streamCallback->id;
     }
 
-    /**
-     * Execute a callback when a signal is received.
-     *
-     * Warning: Installing the same signal on different instances of this interface is deemed undefined behavior.
-     * Implementations MAY try to detect this, if possible, but are not required to. This is due to technical
-     * limitations of the signals being registered globally per process.
-     *
-     * Multiple callbacks on the same signal MAY be executed in any order.
-     *
-     * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
-     * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
-     *
-     * @param int      $signo The signal number to monitor.
-     * @param \Closure $closure The callback to execute.
-     *
-     * @return string A unique identifier that can be used to cancel, enable or disable the callback.
-     *
-     * @throws UnsupportedFeatureException If signal handling is not supported.
-     */
-    public function onSignal(int $signo, \Closure $closure): string
+    public function onSignal(int $signal, \Closure $closure): string
     {
-        $signalCallback = new SignalCallback($this->nextId++, $closure, $signo);
+        $signalCallback = new SignalCallback($this->nextId++, $closure, $signal);
 
         $this->callbacks[$signalCallback->id] = $signalCallback;
         $this->enableQueue[$signalCallback->id] = $signalCallback;
@@ -343,18 +209,6 @@ abstract class AbstractDriver implements Driver
         return $signalCallback->id;
     }
 
-    /**
-     * Enable a callback to be active starting in the next tick.
-     *
-     * Callbacks MUST immediately be marked as enabled, but only be activated (i.e. callbacks can be called) right
-     * before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
-     *
-     * @param string $callbackId The callback identifier.
-     *
-     * @return string The callback identifier.
-     *
-     * @throws InvalidCallbackError If the callback identifier is invalid.
-     */
     public function enable(string $callbackId): string
     {
         if (!isset($this->callbacks[$callbackId])) {
@@ -381,33 +235,12 @@ abstract class AbstractDriver implements Driver
         return $callbackId;
     }
 
-    /**
-     * Cancel a callback.
-     *
-     * This will detach the event loop from all resources that are associated to the callback. After this operation the
-     * callback is permanently invalid. Calling this function MUST NOT fail, even if passed an invalid identifier.
-     *
-     * @param string $callbackId The callback identifier.
-     */
     public function cancel(string $callbackId): void
     {
         $this->disable($callbackId);
         unset($this->callbacks[$callbackId]);
     }
 
-    /**
-     * Disable a callback immediately.
-     *
-     * A callback MUST be disabled immediately, e.g. if a deferred callback disables another deferred callback,
-     * the second deferred callback isn't executed in this tick.
-     *
-     * Disabling a callback MUST NOT invalidate the callback. Calling this function MUST NOT fail, even if passed an
-     * invalid identifier.
-     *
-     * @param string $callbackId The callback identifier.
-     *
-     * @return string The callback identifier.
-     */
     public function disable(string $callbackId): string
     {
         if (!isset($this->callbacks[$callbackId])) {
@@ -442,18 +275,6 @@ abstract class AbstractDriver implements Driver
         return $callbackId;
     }
 
-    /**
-     * Reference a callback.
-     *
-     * This will keep the event loop alive whilst the event is still being monitored. Callbacks have this state by
-     * default.
-     *
-     * @param string $callbackId The callback identifier.
-     *
-     * @return string The callback identifier.
-     *
-     * @throws InvalidCallbackError If the callback identifier is invalid.
-     */
     public function reference(string $callbackId): string
     {
         if (!isset($this->callbacks[$callbackId])) {
@@ -465,16 +286,6 @@ abstract class AbstractDriver implements Driver
         return $callbackId;
     }
 
-    /**
-     * Unreference a callback.
-     *
-     * The event loop should exit the run method when only unreferenced callbacks are still being monitored. Callbacks
-     * are all referenced by default.
-     *
-     * @param string $callbackId The callback identifier.
-     *
-     * @return string The callback identifier.
-     */
     public function unreference(string $callbackId): string
     {
         if (!isset($this->callbacks[$callbackId])) {
@@ -494,19 +305,6 @@ abstract class AbstractDriver implements Driver
         return new DriverSuspension($this->runCallback, $this->queueCallback, $this->interruptCallback);
     }
 
-    /**
-     * Set a callback to be executed when an error occurs.
-     *
-     * The callback receives the error as the first and only parameter. The return value of the callback gets ignored.
-     * If it can't handle the error, it MUST throw the error. Errors thrown by the callback or during its invocation
-     * MUST be thrown into the `run` loop and stop the driver.
-     *
-     * Subsequent calls to this method will overwrite the previous handler.
-     *
-     * @param \Closure|null $closure The callback to execute. `null` will clear the current handler.
-     *
-     * @return \Closure|null The previous handler, `null` if there was none.
-     */
     public function setErrorHandler(\Closure $closure = null): ?callable
     {
         $previous = $this->errorHandler;
@@ -514,11 +312,6 @@ abstract class AbstractDriver implements Driver
         return $previous;
     }
 
-    /**
-     * Returns the same array of data as getInfo().
-     *
-     * @return array
-     */
     public function __debugInfo(): array
     {
         // @codeCoverageIgnoreStart
@@ -526,26 +319,6 @@ abstract class AbstractDriver implements Driver
         // @codeCoverageIgnoreEnd
     }
 
-    /**
-     * Retrieve an associative array of information about the event loop driver.
-     *
-     * The returned array MUST contain the following data describing the driver's currently registered callbacks:
-     *
-     *     [
-     *         "defer"            => ["enabled" => int, "disabled" => int],
-     *         "delay"            => ["enabled" => int, "disabled" => int],
-     *         "repeat"           => ["enabled" => int, "disabled" => int],
-     *         "on_readable"      => ["enabled" => int, "disabled" => int],
-     *         "on_writable"      => ["enabled" => int, "disabled" => int],
-     *         "on_signal"        => ["enabled" => int, "disabled" => int],
-     *         "enabled_watchers" => ["referenced" => int, "unreferenced" => int],
-     *     ];
-     *
-     * Implementations MAY optionally add more information in the array but at minimum the above `key => value` format
-     * MUST always be provided.
-     *
-     * @return array Statistics about the loop in the described format.
-     */
     public function getInfo(): array
     {
         $counts = [

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -2,11 +2,9 @@
 
 namespace Revolt\EventLoop\Internal;
 
-use Revolt\EventLoop;
 use Revolt\EventLoop\Driver;
 use Revolt\EventLoop\InvalidCallbackError;
 use Revolt\EventLoop\Suspension;
-use Revolt\EventLoop\UnsupportedFeatureException;
 
 /**
  * Event loop driver which implements all basic operations to allow interoperability.

--- a/src/EventLoop/Internal/Callback.php
+++ b/src/EventLoop/Internal/Callback.php
@@ -11,14 +11,13 @@ abstract class Callback
 
     public bool $referenced = true;
 
-    /** @var callable */
-    public $callback;
+    public \Closure $closure;
 
     public function __construct(
         public string $id,
-        callable $callback
+        \Closure $closure
     ) {
-        $this->callback = $callback;
+        $this->closure = $closure;
     }
 
     /**

--- a/src/EventLoop/Internal/DriverSuspension.php
+++ b/src/EventLoop/Internal/DriverSuspension.php
@@ -45,7 +45,7 @@ final class DriverSuspension implements Suspension
         $this->pending = false;
 
         if ($this->fiber) {
-            ($this->queue)([$this->fiber, 'resume'], $value);
+            ($this->queue)(\Closure::fromCallable([$this->fiber, 'resume']), $value);
         } else {
             // Suspend event loop fiber to {main}.
             ($this->interrupt)(static fn () => $value);
@@ -97,7 +97,7 @@ final class DriverSuspension implements Suspension
         $this->pending = false;
 
         if ($this->fiber) {
-            ($this->queue)([$this->fiber, 'throw'], $throwable);
+            ($this->queue)(\Closure::fromCallable([$this->fiber, 'throw']), $throwable);
         } else {
             // Suspend event loop fiber to {main}.
             ($this->interrupt)(static fn () => throw $throwable);

--- a/src/EventLoop/Internal/SignalCallback.php
+++ b/src/EventLoop/Internal/SignalCallback.php
@@ -7,9 +7,9 @@ final class SignalCallback extends Callback
 {
     public function __construct(
         string $id,
-        callable $callback,
+        \Closure $closure,
         public int $signal
     ) {
-        parent::__construct($id, $callback);
+        parent::__construct($id, $closure);
     }
 }

--- a/src/EventLoop/Internal/StreamCallback.php
+++ b/src/EventLoop/Internal/StreamCallback.php
@@ -10,9 +10,9 @@ abstract class StreamCallback extends Callback
      */
     public function __construct(
         string $id,
-        callable $callback,
+        \Closure $closure,
         public mixed $stream
     ) {
-        parent::__construct($id, $callback);
+        parent::__construct($id, $closure);
     }
 }

--- a/src/EventLoop/Internal/TimerCallback.php
+++ b/src/EventLoop/Internal/TimerCallback.php
@@ -8,7 +8,7 @@ final class TimerCallback extends Callback
     public function __construct(
         string $id,
         public float $interval,
-        callable $callback,
+        \Closure $callback,
         public float $expiration,
         public bool $repeat = false
     ) {

--- a/test/Driver/DriverTest.php
+++ b/test/Driver/DriverTest.php
@@ -867,10 +867,10 @@ abstract class DriverTest extends TestCase
                 });
 
                 $f = function () use ($loop): array {
-                    $callbacks[] = $loop->defer([$this, "fail"]);
-                    $callbacks[] = $loop->delay(0, [$this, "fail"]);
-                    $callbacks[] = $loop->repeat(0, [$this, "fail"]);
-                    $callbacks[] = $loop->onWritable(STDIN, [$this, "fail"]);
+                    $callbacks[] = $loop->defer(\Closure::fromCallable([$this, "fail"]));
+                    $callbacks[] = $loop->delay(0, \Closure::fromCallable([$this, "fail"]));
+                    $callbacks[] = $loop->repeat(0, \Closure::fromCallable([$this, "fail"]));
+                    $callbacks[] = $loop->onWritable(STDIN, \Closure::fromCallable([$this, "fail"]));
                     return $callbacks;
                 };
                 $callbacks = $f();
@@ -889,11 +889,11 @@ abstract class DriverTest extends TestCase
             $increment++;
         });
         $this->loop->disable($callbackId);
-        $this->loop->delay(0.005, [$this->loop, "stop"]);
+        $this->loop->delay(0.005, \Closure::fromCallable([$this->loop, "stop"]));
         $this->loop->run();
         self::assertSame(0, $increment);
         $this->loop->enable($callbackId);
-        $this->loop->delay(0.005, [$this->loop, "stop"]);
+        $this->loop->delay(0.005, \Closure::fromCallable([$this->loop, "stop"]));
         $this->loop->run();
         self::assertSame(1, $increment);
     }
@@ -902,7 +902,7 @@ abstract class DriverTest extends TestCase
     {
         $increment = 0;
         $this->start(function (Driver $loop) use (&$increment): void {
-            $loop->defer([$loop, "stop"]);
+            $loop->defer(\Closure::fromCallable([$loop, "stop"]));
             $loop->run();
 
             $loop->defer(function () use (&$increment, $loop): void {
@@ -967,7 +967,7 @@ abstract class DriverTest extends TestCase
             });
 
             $loop->disable($callbackId);
-            $loop->delay(0.005, [$loop, "stop"]);
+            $loop->delay(0.005, \Closure::fromCallable([$loop, "stop"]));
 
             $this->assertSame(0, $increment);
         });
@@ -980,7 +980,7 @@ abstract class DriverTest extends TestCase
             $loop->defer(function () use (&$increment): void {
                 $increment++;
             });
-            $loop->defer([$loop, "stop"]);
+            $loop->defer(\Closure::fromCallable([$loop, "stop"]));
         });
         self::assertSame(1, $increment);
     }
@@ -995,7 +995,7 @@ abstract class DriverTest extends TestCase
                     $increment++;
                 });
             });
-            $loop->defer([$loop, "stop"]);
+            $loop->defer(\Closure::fromCallable([$loop, "stop"]));
         });
         self::assertSame(1, $increment);
     }
@@ -1142,7 +1142,7 @@ abstract class DriverTest extends TestCase
                 $invoked = true;
             });
 
-            $loop->delay(0.005, [$loop, "stop"]);
+            $loop->delay(0.005, \Closure::fromCallable([$loop, "stop"]));
         });
 
         self::assertTrue($invoked);
@@ -1156,7 +1156,7 @@ abstract class DriverTest extends TestCase
                 $flag = true;
                 $loop->stop();
             });
-            $loop->delay(0.005, [$loop, "stop"]);
+            $loop->delay(0.005, \Closure::fromCallable([$loop, "stop"]));
         });
         self::assertTrue($flag);
     }
@@ -1169,7 +1169,7 @@ abstract class DriverTest extends TestCase
                 $increment++;
             });
             $loop->disable($callbackId);
-            $loop->delay(0.005, [$loop, "stop"]);
+            $loop->delay(0.005, \Closure::fromCallable([$loop, "stop"]));
         });
         self::assertSame(0, $increment);
     }
@@ -1198,7 +1198,7 @@ abstract class DriverTest extends TestCase
             $loop->onWritable(STDOUT, function () {
                 throw new \RuntimeException();
             });
-            $loop->delay(0.005, [$loop, "stop"]);
+            $loop->delay(0.005, \Closure::fromCallable([$loop, "stop"]));
         });
     }
 
@@ -1280,7 +1280,7 @@ abstract class DriverTest extends TestCase
                     $this->fail("Timer was executed despite stopped loop");
                 });
             });
-            $loop->defer([$loop, "stop"]);
+            $loop->defer(\Closure::fromCallable([$loop, "stop"]));
         });
         self::assertGreaterThan(\microtime(1), $t + 0.1);
     }
@@ -1288,7 +1288,7 @@ abstract class DriverTest extends TestCase
     public function testDeferEnabledInNextTick(): void
     {
         $tick = function () {
-            $this->loop->defer([$this->loop, "stop"]);
+            $this->loop->defer(\Closure::fromCallable([$this->loop, "stop"]));
             $this->loop->run();
         };
 


### PR DESCRIPTION
`callable` is a problematic type, because it's scope dependent. It can therefore not be used for typed properties, but `\Closure` can be used as a safe replacement, especially with first-class syntax introduced in PHP 8.1: `(...)`.

Resolves #14.