### PR TITLE
Remove default value for setErrorHandler

### DIFF
--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -299,13 +299,13 @@ final class EventLoop
      *
      * Subsequent calls to this method will overwrite the previous handler.
      *
-     * @param (\Closure(\Throwable):void)|null $closure The callback to execute. `null` will clear the current handler.
+     * @param (\Closure(\Throwable):void)|null $errorHandler The callback to execute. `null` will clear the current handler.
      *
      * @return (\Closure(\Throwable):void)|null The previous handler, `null` if there was none.
      */
-    public static function setErrorHandler(\Closure $closure = null): ?\Closure
+    public static function setErrorHandler(?\Closure $errorHandler): ?\Closure
     {
-        return self::getDriver()->setErrorHandler($closure);
+        return self::getDriver()->setErrorHandler($errorHandler);
     }
 
     /**

--- a/src/EventLoop/Driver.php
+++ b/src/EventLoop/Driver.php
@@ -240,11 +240,11 @@ interface Driver
      *
      * Subsequent calls to this method will overwrite the previous handler.
      *
-     * @param (\Closure(\Throwable):void)|null $closure The callback to execute. `null` will clear the current handler.
+     * @param (\Closure(\Throwable):void)|null $errorHandler The callback to execute. `null` will clear the current handler.
      *
      * @return (\Closure(\Throwable):void)|null The previous handler, `null` if there was none.
      */
-    public function setErrorHandler(?\Closure $closure = null): ?callable;
+    public function setErrorHandler(?\Closure $errorHandler): ?callable;
 
     /**
      * Get the underlying loop handle.

--- a/src/EventLoop/Driver/TracingDriver.php
+++ b/src/EventLoop/Driver/TracingDriver.php
@@ -170,9 +170,9 @@ final class TracingDriver implements Driver
         return $callbackId;
     }
 
-    public function setErrorHandler(\Closure $closure = null): ?callable
+    public function setErrorHandler(?\Closure $errorHandler): ?callable
     {
-        return $this->driver->setErrorHandler($closure);
+        return $this->driver->setErrorHandler($errorHandler);
     }
 
     /** @inheritdoc */

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -303,10 +303,10 @@ abstract class AbstractDriver implements Driver
         return new DriverSuspension($this->runCallback, $this->queueCallback, $this->interruptCallback);
     }
 
-    public function setErrorHandler(\Closure $closure = null): ?callable
+    public function setErrorHandler(?\Closure $errorHandler): ?callable
     {
         $previous = $this->errorHandler;
-        $this->errorHandler = $closure;
+        $this->errorHandler = $errorHandler;
         return $previous;
     }
 


### PR DESCRIPTION
`setErrorHandler()` looks weird and IDEs will flag `setErrorHandler(null)` as passing an unnecessary parameter.

We should likely also make it `void` and introduce a separate `getErrorHandler()`.