### PR TITLE
Always rethrow errors in DriverSuspension

### DIFF
--- a/src/EventLoop/Internal/DriverSuspension.php
+++ b/src/EventLoop/Internal/DriverSuspension.php
@@ -77,7 +77,7 @@ final class DriverSuspension implements Suspension
         }
 
         // Awaiting from {main}.
-        $lambda = ($this->run)();
+        $result = ($this->run)()();
 
         /** @psalm-suppress RedundantCondition $this->pending should be changed when resumed. */
         if ($this->pending) {
@@ -85,7 +85,7 @@ final class DriverSuspension implements Suspension
             throw new \Error('Scheduler suspended or exited unexpectedly');
         }
 
-        return $lambda();
+        return $result;
     }
 
     public function throw(\Throwable $throwable): void

--- a/test/EventLoopTest.php
+++ b/test/EventLoopTest.php
@@ -197,4 +197,18 @@ class EventLoopTest extends TestCase
 
         self::assertSame($send, $received);
     }
+
+    public function testSuspensionThrowingErrorViaInterrupt(): void
+    {
+        $suspension = EventLoop::createSuspension();
+        $error = new \Error("Test error");
+        EventLoop::queue(static fn () => throw $error);
+        EventLoop::defer(static fn () => $suspension->resume("Value"));
+        try {
+            $suspension->suspend();
+            self::fail("Error was not thrown");
+        } catch (\Throwable $t) {
+            self::assertSame($error, $t);
+        }
+    }
 }


### PR DESCRIPTION
First acquire the result - which may throw if any error is unhandled within the loop (i.e. AbstractDriver::invokeInterrupt() is firing); only then check for $this->pending.

This fixes some nasty exception hiding.