### PR TITLE
Reduce fiber switches by queuing callbacks for each tick

### DIFF
--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -153,8 +153,8 @@ final class EventLoop
      * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
-     * @param resource|object $stream The stream to monitor.
-     * @param \Closure(string, resource|object):void $callback The callback to execute.
+     * @param resource $stream The stream to monitor.
+     * @param \Closure(string, resource):void $closure The callback to execute.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
@@ -176,8 +176,8 @@ final class EventLoop
      * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
-     * @param resource|object $stream The stream to monitor.
-     * @param \Closure(string, resource|object):void $closure The callback to execute.
+     * @param resource $stream The stream to monitor.
+     * @param \Closure(string, resource):void $closure The callback to execute.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -5,7 +5,7 @@ namespace Revolt;
 use Revolt\EventLoop\Driver;
 use Revolt\EventLoop\DriverFactory;
 use Revolt\EventLoop\Internal\AbstractDriver;
-use Revolt\EventLoop\Internal\Callback;
+use Revolt\EventLoop\Internal\DriverCallback;
 use Revolt\EventLoop\InvalidCallbackError;
 use Revolt\EventLoop\Suspension;
 use Revolt\EventLoop\UnsupportedFeatureException;
@@ -42,7 +42,7 @@ final class EventLoop
                     throw new \Error("Can't dispatch during garbage collection.");
                 }
 
-                protected function deactivate(Callback $callback): void
+                protected function deactivate(DriverCallback $callback): void
                 {
                     // do nothing
                 }

--- a/src/EventLoop/Driver.php
+++ b/src/EventLoop/Driver.php
@@ -118,8 +118,8 @@ interface Driver
      * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
-     * @param resource|object $stream The stream to monitor.
-     * @param \Closure(string, resource|object):void $closure The callback to execute.
+     * @param resource $stream The stream to monitor.
+     * @param \Closure(string, resource):void $closure The callback to execute.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
@@ -138,8 +138,8 @@ interface Driver
      * The created callback MUST immediately be marked as enabled, but only be activated (i.e. callback can be called)
      * right before the next tick. Callbacks MUST NOT be called in the tick they were enabled.
      *
-     * @param resource|object $stream The stream to monitor.
-     * @param \Closure(string, resource|object):void $closure The callback to execute.
+     * @param resource $stream The stream to monitor.
+     * @param \Closure(string, resource):void $closure The callback to execute.
      *
      * @return string A unique identifier that can be used to cancel, enable or disable the callback.
      */
@@ -243,6 +243,8 @@ interface Driver
      * @param (\Closure(\Throwable):void)|null $closure The callback to execute. `null` will clear the current handler.
      *
      * @return (\Closure(\Throwable):void)|null The previous handler, `null` if there was none.
+     *
+     * @psalm-suppress InvalidReturnType TODO: Remove
      */
     public function setErrorHandler(?\Closure $closure = null): ?callable;
 

--- a/src/EventLoop/Driver/UvDriver.php
+++ b/src/EventLoop/Driver/UvDriver.php
@@ -165,7 +165,7 @@ final class UvDriver extends AbstractDriver
                 foreach ($this->callbacks[$eventId] as $w) {
                     \assert($w instanceof StreamCallback);
 
-                    $flags |= $w->invokable ? ($this->getStreamCallbackFlags($w)) : 0;
+                    $flags |= $w->enabled ? ($this->getStreamCallbackFlags($w)) : 0;
                 }
                 \uv_poll_start($event, $flags, $this->ioCallback);
             } elseif ($callback instanceof TimerCallback) {

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -60,7 +60,7 @@ abstract class AbstractDriver implements Driver
     /** @var DriverCallback[] */
     private array $enableDeferQueue = [];
 
-    /** @var \Closure(\Throwable)|null */
+    /** @var null|\Closure(\Throwable) */
     private ?\Closure $errorHandler = null;
     private ?\Closure $interrupt = null;
 
@@ -397,8 +397,6 @@ abstract class AbstractDriver implements Driver
      * Invokes the error handler with the given exception.
      *
      * @param \Throwable $exception The exception thrown from an event callback.
-     *
-     * @throws \Throwable If no error handler has been set.
      */
     final protected function error(\Throwable $exception): void
     {
@@ -408,6 +406,8 @@ abstract class AbstractDriver implements Driver
         }
 
         $fiber = new \Fiber($this->errorCallback);
+
+        /** @noinspection PhpUnhandledExceptionInspection */
         $fiber->start($this->errorHandler, $exception);
     }
 
@@ -428,8 +428,6 @@ abstract class AbstractDriver implements Driver
                 $callback(...$args);
             } catch (\Throwable $exception) {
                 $this->createCallbackFiber();
-
-                // TODO: This might throw
                 $this->error($exception);
             }
 

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -75,7 +75,7 @@ abstract class AbstractDriver implements Driver
     /** @var \SplQueue<DriverCallback> */
     private \SplQueue $callbackQueue;
 
-    private bool $idle = true;
+    private bool $idle = false;
     private bool $stopped = false;
 
     public function __construct()

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -475,13 +475,18 @@ abstract class AbstractDriver implements Driver
 
         $this->enableDeferQueue = [];
 
-        $this->invokeCallbacks();
-
         $blocking = $previousIdle
-            && empty($this->enableDeferQueue)
-            && empty($this->enableQueue)
             && !$this->stopped
             && !$this->isEmpty();
+
+        if ($blocking) {
+            $this->invokeCallbacks();
+
+            /** @psalm-suppress TypeDoesNotContainType */
+            if (!empty($this->enableDeferQueue) || !empty($this->enableQueue)) {
+                $blocking = false;
+            }
+        }
 
         /** @psalm-suppress RedundantCondition */
         $this->dispatch($blocking);

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -60,6 +60,7 @@ abstract class AbstractDriver implements Driver
     /** @var DriverCallback[] */
     private array $enableDeferQueue = [];
 
+    /** @var \Closure(\Throwable)|null */
     private ?\Closure $errorHandler = null;
     private ?\Closure $interrupt = null;
 

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -585,10 +585,14 @@ abstract class AbstractDriver implements Driver
 
                     try {
                         $result = match (true) {
-                            $callback instanceof StreamCallback => ($callback->closure)($callback->id,
-                                $callback->stream),
-                            $callback instanceof SignalCallback => ($callback->closure)($callback->id,
-                                $callback->signal),
+                            $callback instanceof StreamCallback => ($callback->closure)(
+                                $callback->id,
+                                $callback->stream
+                            ),
+                            $callback instanceof SignalCallback => ($callback->closure)(
+                                $callback->id,
+                                $callback->signal
+                            ),
                             default => ($callback->closure)($callback->id),
                         };
 

--- a/src/EventLoop/Internal/DeferCallback.php
+++ b/src/EventLoop/Internal/DeferCallback.php
@@ -3,6 +3,6 @@
 namespace Revolt\EventLoop\Internal;
 
 /** @internal */
-final class DeferCallback extends Callback
+final class DeferCallback extends DriverCallback
 {
 }

--- a/src/EventLoop/Internal/DriverCallback.php
+++ b/src/EventLoop/Internal/DriverCallback.php
@@ -5,8 +5,10 @@ namespace Revolt\EventLoop\Internal;
 /**
  * @internal
  */
-abstract class Callback
+abstract class DriverCallback
 {
+    public bool $invokable = true;
+
     public bool $enabled = true;
 
     public bool $referenced = true;

--- a/src/EventLoop/Internal/DriverCallback.php
+++ b/src/EventLoop/Internal/DriverCallback.php
@@ -7,7 +7,7 @@ namespace Revolt\EventLoop\Internal;
  */
 abstract class DriverCallback
 {
-    public bool $invokable = true;
+    public bool $invokable = false;
 
     public bool $enabled = true;
 

--- a/src/EventLoop/Internal/SignalCallback.php
+++ b/src/EventLoop/Internal/SignalCallback.php
@@ -3,7 +3,7 @@
 namespace Revolt\EventLoop\Internal;
 
 /** @internal */
-final class SignalCallback extends Callback
+final class SignalCallback extends DriverCallback
 {
     public function __construct(
         string $id,

--- a/src/EventLoop/Internal/StreamCallback.php
+++ b/src/EventLoop/Internal/StreamCallback.php
@@ -3,7 +3,7 @@
 namespace Revolt\EventLoop\Internal;
 
 /** @internal */
-abstract class StreamCallback extends Callback
+abstract class StreamCallback extends DriverCallback
 {
     /**
      * @param resource|object $stream

--- a/src/EventLoop/Internal/TimerCallback.php
+++ b/src/EventLoop/Internal/TimerCallback.php
@@ -3,7 +3,7 @@
 namespace Revolt\EventLoop\Internal;
 
 /** @internal */
-final class TimerCallback extends Callback
+final class TimerCallback extends DriverCallback
 {
     public function __construct(
         string $id,

--- a/test/Driver/DriverTest.php
+++ b/test/Driver/DriverTest.php
@@ -60,7 +60,7 @@ abstract class DriverTest extends TestCase
         self::assertNotSame(0, $start);
         self::assertNotSame(0, $invoked);
 
-        self::assertGreaterThanOrEqual(1, $invoked - $start);
+        self::assertGreaterThanOrEqual(0.9995, $invoked - $start);
         self::assertLessThan(1.1, $invoked - $start);
     }
 

--- a/test/Driver/DriverTest.php
+++ b/test/Driver/DriverTest.php
@@ -867,10 +867,10 @@ abstract class DriverTest extends TestCase
                 });
 
                 $f = function () use ($loop): array {
-                    $callbacks[] = $loop->defer(\Closure::fromCallable([$this, "fail"]));
-                    $callbacks[] = $loop->delay(0, \Closure::fromCallable([$this, "fail"]));
-                    $callbacks[] = $loop->repeat(0, \Closure::fromCallable([$this, "fail"]));
-                    $callbacks[] = $loop->onWritable(STDIN, \Closure::fromCallable([$this, "fail"]));
+                    $callbacks[] = $loop->defer(fn () => $this->fail());
+                    $callbacks[] = $loop->delay(0, fn () => $this->fail());
+                    $callbacks[] = $loop->repeat(0, fn () => $this->fail());
+                    $callbacks[] = $loop->onWritable(STDIN, fn () => $this->fail());
                     return $callbacks;
                 };
                 $callbacks = $f();
@@ -1091,7 +1091,7 @@ abstract class DriverTest extends TestCase
 
         $this->expectOutputString("caught SIGUSR1");
         $this->start(function (Driver $loop): void {
-            $loop->delay(0.001, function () use ($loop): void {
+            $loop->delay(0.001, function (): void {
                 \posix_kill(\getmypid(), \SIGUSR1);
             });
 

--- a/test/Driver/DriverTest.php
+++ b/test/Driver/DriverTest.php
@@ -258,55 +258,58 @@ abstract class DriverTest extends TestCase
         });
     }
 
-    public function provideRegistrationArgs(): array
+    public function provideRegistrationArgs(): iterable
     {
-        return [
+        yield "defer" => [
+            "defer",
             [
-                "defer",
-                [
-                    static function () {
-                    },
-                ],
+                static function () {
+                },
             ],
+        ];
+
+        yield "delay" => [
+            "delay",
             [
-                "delay",
-                [
-                    0.005,
-                    static function () {
-                    },
-                ],
+                0.005,
+                static function () {
+                },
             ],
+        ];
+
+        yield "repeat" => [
+            "repeat",
             [
-                "repeat",
-                [
-                    0.005,
-                    static function () {
-                    },
-                ],
+                0.005,
+                static function () {
+                },
             ],
+        ];
+
+        yield "onWritable" => [
+            "onWritable",
             [
-                "onWritable",
-                [
-                    \STDOUT,
-                    static function () {
-                    },
-                ],
+                \STDOUT,
+                static function () {
+                },
             ],
+        ];
+
+        yield "onReadable" => [
+            "onReadable",
             [
-                "onReadable",
-                [
-                    \STDIN,
-                    static function () {
-                    },
-                ],
+                \STDIN,
+                static function () {
+                },
             ],
+        ];
+
+        yield "onSignal" => [
+            "onSignal",
             [
-                "onSignal",
-                [
-                    \SIGUSR1,
-                    static function () {
-                    },
-                ],
+                \SIGUSR1,
+                static function () {
+                },
             ],
         ];
     }
@@ -599,12 +602,12 @@ abstract class DriverTest extends TestCase
 
                             if ($i--) {
                                 $loop->onSignal(\SIGUSR1, $fn);
-                                $loop->delay(0.001, $sendSignal);
+                                $loop->delay(0, $sendSignal);
                             }
                             $loop->cancel($callbackId);
                         }
                     );
-                    $loop->delay(0.001, $sendSignal);
+                    $loop->delay(0, $sendSignal);
                     $loop->run();
                 }
             };


### PR DESCRIPTION
This massively reduces the number of fibers switches. Before, we usually had a switch to the event loop, another to the callback fiber, called `Suspension::resume()`, switched back to the event loop, switched to the microtask fiber, switched to the fiber that suspended to await an event. Now we switch to the event loop, switch to the callback fiber once per tick (if non-blocking and there's no suspend within the callback) and switch to the original fiber.