### PR TITLE
Cache suspensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "ext-json": "*",
         "phpunit/phpunit": "^9",
         "jetbrains/phpstorm-stubs": "^2019.3",
-        "psalm/phar": "^4.7"
+        "psalm/phar": "^4.7",
+        "jetbrains/phpstorm-attributes": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
         "ext-json": "*",
         "phpunit/phpunit": "^9",
         "jetbrains/phpstorm-stubs": "^2019.3",
-        "psalm/phar": "^4.7",
-        "jetbrains/phpstorm-attributes": "^1.0"
+        "psalm/phar": "^4.7"
     },
     "autoload": {
         "psr-4": {

--- a/examples/http-client-suspension.php
+++ b/examples/http-client-suspension.php
@@ -6,7 +6,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 function fetch(string $url): string
 {
-    $suspension = EventLoop::createSuspension();
+    $suspension = EventLoop::getSuspension();
 
     $parsedUrl = \parse_url($url);
     if (!isset($parsedUrl['host'], $parsedUrl['path'])) {

--- a/examples/invalid-callback-return.php
+++ b/examples/invalid-callback-return.php
@@ -7,7 +7,7 @@ use Revolt\EventLoop;
 
 print "Press Ctrl+C to exit..." . PHP_EOL;
 
-$suspension = EventLoop::createSuspension();
+$suspension = EventLoop::getSuspension();
 
 EventLoop::onSignal(\SIGINT, function (string $watcherId) use ($suspension) {
     EventLoop::cancel($watcherId);

--- a/examples/stdin-timeout.php
+++ b/examples/stdin-timeout.php
@@ -12,7 +12,7 @@ if (\stream_set_blocking(STDIN, false) !== true) {
 
 print "Write something and hit enter" . PHP_EOL;
 
-$suspension = EventLoop::createSuspension();
+$suspension = EventLoop::getSuspension();
 
 $readWatcher = EventLoop::onReadable(STDIN, function ($watcherId, $stream) use ($suspension) {
     EventLoop::cancel($watcherId);

--- a/examples/stdin.php
+++ b/examples/stdin.php
@@ -12,7 +12,7 @@ if (\stream_set_blocking(STDIN, false) !== true) {
 
 print "Write something and hit enter" . PHP_EOL;
 
-$suspension = EventLoop::createSuspension();
+$suspension = EventLoop::getSuspension();
 
 EventLoop::onReadable(STDIN, function ($watcherId, $stream) use ($suspension) {
     EventLoop::cancel($watcherId);

--- a/examples/timers.php
+++ b/examples/timers.php
@@ -5,7 +5,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 use Revolt\EventLoop;
 
-$suspension = EventLoop::createSuspension();
+$suspension = EventLoop::getSuspension();
 
 $repeatWatcher = EventLoop::repeat(1, function () {
     print "++ Executing watcher created by Loop::repeat()" . PHP_EOL;

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -372,7 +372,6 @@ final class EventLoop
      * @deprecated This old name is only kept temporarily to allow smooth transitions from 0.1 to 0.2 and will be
      *     removed at a later point.
      */
-    #[Deprecated]
     public static function createSuspension(): Suspension
     {
         return self::getDriver()->getSuspension();

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -350,13 +350,15 @@ final class EventLoop
     }
 
     /**
-     * Create an object used to suspend and resume execution, either within a fiber or from {main}.
+     * Returns an object used to suspend and resume execution of the current fiber or {main}.
+     *
+     * Calls from the same fiber will return the same suspension object.
      *
      * @return Suspension
      */
-    public static function createSuspension(): Suspension
+    public static function getSuspension(): Suspension
     {
-        return self::getDriver()->createSuspension();
+        return self::getDriver()->getSuspension();
     }
 
     /**

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -2,6 +2,7 @@
 
 namespace Revolt;
 
+use JetBrains\PhpStorm\Deprecated;
 use Revolt\EventLoop\Driver;
 use Revolt\EventLoop\DriverFactory;
 use Revolt\EventLoop\Internal\AbstractDriver;
@@ -74,7 +75,7 @@ final class EventLoop
      * Use {@see EventLoop::defer()} if you need these features.
      *
      * @param \Closure $closure The callback to queue.
-     * @param mixed    ...$args The callback arguments.
+     * @param mixed ...$args The callback arguments.
      */
     public static function queue(\Closure $closure, mixed ...$args): void
     {
@@ -357,6 +358,22 @@ final class EventLoop
      * @return Suspension
      */
     public static function getSuspension(): Suspension
+    {
+        return self::getDriver()->getSuspension();
+    }
+
+    /**
+     * Returns an object used to suspend and resume execution of the current fiber or {main}.
+     *
+     * Calls from the same fiber will return the same suspension object.
+     *
+     * @return Suspension
+     *
+     * @deprecated This old name is only kept temporarily to allow smooth transitions from 0.1 to 0.2 and will be
+     *     removed at a later point.
+     */
+    #[Deprecated]
+    public static function createSuspension(): Suspension
     {
         return self::getDriver()->getSuspension();
     }

--- a/src/EventLoop/Driver.php
+++ b/src/EventLoop/Driver.php
@@ -30,11 +30,13 @@ interface Driver
     public function stop(): void;
 
     /**
-     * Create an object used to suspend and resume execution, either within a fiber or from {main}.
+     * Returns an object used to suspend and resume execution of the current fiber or {main}.
+     *
+     * Calls from the same fiber will return the same suspension object.
      *
      * @return Suspension
      */
-    public function createSuspension(): Suspension;
+    public function getSuspension(): Suspension;
 
     /**
      * @return bool True if the event loop is running, false if it is stopped.

--- a/src/EventLoop/Driver/TracingDriver.php
+++ b/src/EventLoop/Driver/TracingDriver.php
@@ -37,9 +37,9 @@ final class TracingDriver implements Driver
         $this->driver->stop();
     }
 
-    public function createSuspension(): Suspension
+    public function getSuspension(): Suspension
     {
-        return $this->driver->createSuspension();
+        return $this->driver->getSuspension();
     }
 
     public function isRunning(): bool

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -297,7 +297,7 @@ abstract class AbstractDriver implements Driver
         return $callbackId;
     }
 
-    public function createSuspension(): Suspension
+    public function getSuspension(): Suspension
     {
         $fiber = \Fiber::getCurrent();
 

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -304,7 +304,8 @@ abstract class AbstractDriver implements Driver
         // User callbacks are always executed outside the event loop fiber, so this should always be false.
         \assert($fiber !== $this->fiber);
 
-        return $this->suspensions[$fiber] ??= new DriverSuspension(
+        // Use current object in case of {main}
+        return $this->suspensions[$fiber ?? $this] ??= new DriverSuspension(
             $this->runCallback,
             $this->queueCallback,
             $this->interruptCallback

--- a/test/EventLoopTest.php
+++ b/test/EventLoopTest.php
@@ -31,7 +31,7 @@ class EventLoopTest extends TestCase
         \fwrite($ends[0], "trigger readability callback");
 
         $count = 0;
-        $suspension = EventLoop::createSuspension();
+        $suspension = EventLoop::getSuspension();
 
         EventLoop::onReadable($ends[1], function ($callbackId) use (&$count, $suspension): void {
             $this->assertTrue(true);
@@ -49,7 +49,7 @@ class EventLoopTest extends TestCase
     public function testOnWritable(): void
     {
         $count = 0;
-        $suspension = EventLoop::createSuspension();
+        $suspension = EventLoop::getSuspension();
 
         EventLoop::onWritable(STDOUT, function ($callbackId) use (&$count, $suspension): void {
             $this->assertTrue(true);
@@ -115,7 +115,7 @@ class EventLoopTest extends TestCase
 
     public function testRunAfterSuspension(): void
     {
-        $suspension = EventLoop::createSuspension();
+        $suspension = EventLoop::getSuspension();
 
         EventLoop::defer(fn () => $suspension->resume('test'));
 
@@ -142,7 +142,7 @@ class EventLoopTest extends TestCase
 
         self::assertTrue($invoked);
 
-        $suspension = EventLoop::createSuspension();
+        $suspension = EventLoop::getSuspension();
 
         EventLoop::defer(fn () => $suspension->resume('test'));
 
@@ -154,7 +154,7 @@ class EventLoopTest extends TestCase
         $invoked = false;
 
         EventLoop::queue(function () use (&$invoked): void {
-            $suspension = EventLoop::createSuspension();
+            $suspension = EventLoop::getSuspension();
 
             EventLoop::defer(fn () => $suspension->resume('test'));
 
@@ -173,7 +173,7 @@ class EventLoopTest extends TestCase
         $send = 42;
 
         EventLoop::defer(static function () use (&$received, $send): void {
-            $suspension = EventLoop::createSuspension();
+            $suspension = EventLoop::getSuspension();
             EventLoop::defer(static fn () => $suspension->resume($send));
             $received = $suspension->suspend();
         });
@@ -188,7 +188,7 @@ class EventLoopTest extends TestCase
         $send = 42;
 
         EventLoop::queue(static function () use (&$received, $send): void {
-            $suspension = EventLoop::createSuspension();
+            $suspension = EventLoop::getSuspension();
             EventLoop::defer(static fn () => $suspension->resume($send));
             $received = $suspension->suspend();
         });
@@ -200,7 +200,7 @@ class EventLoopTest extends TestCase
 
     public function testSuspensionThrowingErrorViaInterrupt(): void
     {
-        $suspension = EventLoop::createSuspension();
+        $suspension = EventLoop::getSuspension();
         $error = new \Error("Test error");
         EventLoop::queue(static fn () => throw $error);
         EventLoop::defer(static fn () => $suspension->resume("Value"));


### PR DESCRIPTION
Not sure whether this is useful. If we go that route, we should rename `createSuspension` into `getSuspension`.