### PR TITLE
Add FiberLocal::unset

### DIFF
--- a/src/EventLoop/FiberLocal.php
+++ b/src/EventLoop/FiberLocal.php
@@ -53,12 +53,15 @@ final class FiberLocal
 
     /**
      * @param T $value
-     *
-     * @return void
      */
     public function set(mixed $value): void
     {
         self::getFiberStorage()[$this] = [$value];
+    }
+
+    public function unset(): void
+    {
+        unset(self::getFiberStorage()[$this]);
     }
 
     /**

--- a/test/FiberLocalTest.php
+++ b/test/FiberLocalTest.php
@@ -140,4 +140,30 @@ class FiberLocalTest extends TestCase
         self::assertNull($fiberLocal->get());
         self::assertSame(1, $invoked);
     }
+
+    public function testInitializeThrow(): void
+    {
+        $fiberLocal = new FiberLocal(fn () => throw new \Exception('test'));
+
+        self::assertThrows(static fn () => $fiberLocal->get(), \Exception::class);
+
+        // throws repeatedly
+        self::assertThrows(static fn () => $fiberLocal->get(), \Exception::class);
+
+        $fiberLocal->set(null);
+        self::assertNull($fiberLocal->get());
+
+        $fiberLocal->unset();
+        self::assertThrows(static fn () => $fiberLocal->get(), \Exception::class);
+    }
+
+    private static function assertThrows(\Closure $closure, string $exceptionClass): void
+    {
+        try {
+            $closure();
+            self::fail('Expected ' . $exceptionClass . ' to be thrown');
+        } catch (\Throwable $exception) {
+            self::assertInstanceOf($exceptionClass, $exception);
+        }
+    }
 }


### PR DESCRIPTION
We'd like to use this in https://github.com/amphp/pipeline. We could use a second `FiberLocal` there, but adding `unset` seems reasonable.