### PR TITLE
Remove unnecessary export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 .github export-ignore
-docs export-ignore
 examples export-ignore
 stubs export-ignore
 test export-ignore


### PR DESCRIPTION
Hi,

This PR removes an unnecessary `export-ignore` line from the `.gitattributes` file.

The `docs` folder does not exist in the repository and seems to never have existed.

Best regards