### PR TITLE
Fix overflow on large timers

### DIFF
--- a/src/EventLoop/Driver/EventDriver.php
+++ b/src/EventLoop/Driver/EventDriver.php
@@ -210,7 +210,7 @@ final class EventDriver extends AbstractDriver
             }
 
             if ($callback instanceof TimerCallback) {
-                $interval = \max(0, $callback->expiration - $now);
+                $interval = \min(\max(0, $callback->expiration - $now), \PHP_INT_MAX / 2);
                 $this->events[$id]->add($interval > 0 ? $interval : 0);
             } elseif ($callback instanceof SignalCallback) {
                 $this->signals[$id] = $this->events[$id];

--- a/src/EventLoop/Driver/UvDriver.php
+++ b/src/EventLoop/Driver/UvDriver.php
@@ -179,8 +179,8 @@ final class UvDriver extends AbstractDriver
 
                 \uv_timer_start(
                     $event,
-                    (int) \ceil(\max(0, $callback->expiration - $now) * 1000),
-                    $callback->repeat ? (int) \ceil($callback->interval * 1000) : 0,
+                    (int) \min(\max(0, \ceil(($callback->expiration - $now) * 1000)), \PHP_INT_MAX),
+                    $callback->repeat ? (int) \min(\max(0, \ceil($callback->interval * 1000)), \PHP_INT_MAX) : 0,
                     $this->timerCallback
                 );
             } elseif ($callback instanceof SignalCallback) {

--- a/test/Driver/DriverTest.php
+++ b/test/Driver/DriverTest.php
@@ -1609,6 +1609,40 @@ abstract class DriverTest extends TestCase
         self::assertNotSame(0, $j);
     }
 
+    public function testLargeDelayTimer(): void
+    {
+        $invoked = false;
+
+        $this->loop->delay(\PHP_INT_MAX, function () use (&$invoked) {
+            $invoked = true;
+        });
+
+        $this->loop->delay(0.002, function () {
+            $this->loop->stop();
+        });
+
+        $this->loop->run();
+
+        self::assertFalse($invoked);
+    }
+
+    public function testLargeRepeatTimer(): void
+    {
+        $invoked = false;
+
+        $this->loop->repeat(\PHP_INT_MAX, function () use (&$invoked) {
+            $invoked = true;
+        });
+
+        $this->loop->delay(0.002, function () {
+            $this->loop->stop();
+        });
+
+        $this->loop->run();
+
+        self::assertFalse($invoked);
+    }
+
     protected function start($cb): void
     {
         $cb($this->loop);


### PR DESCRIPTION
We hit this issue in https://github.com/amphp/file/blob/858c2a46fc799e6775c3e992134eae57d1d58c49/src/Internal/UvPoll.php#L17 with a dummy timer to keep the event loop running.