### PR TITLE
Fix reference to Fiber in Suspension causing memory leak

### DIFF
--- a/src/EventLoop/Internal/DriverSuspension.php
+++ b/src/EventLoop/Internal/DriverSuspension.php
@@ -12,7 +12,9 @@ use Revolt\EventLoop\Suspension;
  */
 final class DriverSuspension implements Suspension
 {
-    private ?\Fiber $fiber;
+    private ?\Fiber $suspendedFiber = null;
+
+    private ?\WeakReference $fiberRef;
 
     private ?\FiberError $fiberError = null;
 
@@ -35,10 +37,12 @@ final class DriverSuspension implements Suspension
      */
     public function __construct(\Closure $run, \Closure $queue, \Closure $interrupt, \WeakMap $suspensions)
     {
+        $fiber = \Fiber::getCurrent();
+
         $this->run = $run;
         $this->queue = $queue;
         $this->interrupt = $interrupt;
-        $this->fiber = \Fiber::getCurrent();
+        $this->fiberRef = $fiber ? \WeakReference::create($fiber) : null;
         $this->suspensions = \WeakReference::create($suspensions);
     }
 
@@ -48,10 +52,11 @@ final class DriverSuspension implements Suspension
             throw $this->fiberError ?? new \Error('Must call suspend() before calling resume()');
         }
 
+        $fiber = $this->suspendedFiber;
         $this->pending = false;
 
-        if ($this->fiber) {
-            ($this->queue)(\Closure::fromCallable([$this->fiber, 'resume']), $value);
+        if ($fiber) {
+            ($this->queue)(\Closure::fromCallable([$fiber, 'resume']), $value);
         } else {
             // Suspend event loop fiber to {main}.
             ($this->interrupt)(static fn () => $value);
@@ -64,14 +69,17 @@ final class DriverSuspension implements Suspension
             throw new \Error('Must call resume() or throw() before calling suspend() again');
         }
 
-        if ($this->fiber !== \Fiber::getCurrent()) {
+        $fiber = $this->fiberRef?->get();
+
+        if ($fiber !== \Fiber::getCurrent()) {
             throw new \Error('Must not call suspend() from another fiber');
         }
 
         $this->pending = true;
+        $this->suspendedFiber = $fiber;
 
         // Awaiting from within a fiber.
-        if ($this->fiber) {
+        if ($fiber) {
             try {
                 return \Fiber::suspend();
             } catch (\FiberError $exception) {
@@ -79,6 +87,8 @@ final class DriverSuspension implements Suspension
                 $this->fiberError = $exception;
 
                 throw $exception;
+            } finally {
+                $this->suspendedFiber = null;
             }
         }
 
@@ -117,10 +127,11 @@ final class DriverSuspension implements Suspension
             throw $this->fiberError ?? new \Error('Must call suspend() before calling throw()');
         }
 
+        $fiber = $this->suspendedFiber;
         $this->pending = false;
 
-        if ($this->fiber) {
-            ($this->queue)(\Closure::fromCallable([$this->fiber, 'throw']), $throwable);
+        if ($fiber) {
+            ($this->queue)(\Closure::fromCallable([$fiber, 'throw']), $throwable);
         } else {
             // Suspend event loop fiber to {main}.
             ($this->interrupt)(static fn () => throw $throwable);


### PR DESCRIPTION
This changes `Suspension` to hold only a weak reference to the associated `Fiber` object while not suspended. Without this, there is a circular reference between the weak map of suspensions and the fiber held within the suspension.

This fixes the memory leak in https://github.com/revoltphp/event-loop/issues/42#issuecomment-1041600341.