### PR TITLE
Add Continuations to help prevent memory leaks

### DIFF
--- a/examples/fiber-local-automatic.php
+++ b/examples/fiber-local-automatic.php
@@ -32,7 +32,8 @@ EventLoop::delay(1, static function () use ($logger) {
     $logger->log('Initializing...');
 
     $suspension = EventLoop::getSuspension();
-    EventLoop::delay(1, static fn () => $suspension->resume());
+    $continuation = $suspension->getContinuation();
+    EventLoop::delay(1, static fn () => $continuation->resume());
     $suspension->suspend();
 
     $logger->log('Done.');
@@ -41,7 +42,8 @@ EventLoop::delay(1, static function () use ($logger) {
 $logger->log('Initializing...');
 
 $suspension = EventLoop::getSuspension();
-EventLoop::delay(3, static fn () => $suspension->resume());
+$continuation = $suspension->getContinuation();
+EventLoop::delay(3, static fn () => $continuation->resume());
 $suspension->suspend();
 
 $logger->log('Done.');

--- a/examples/fiber-local-manual.php
+++ b/examples/fiber-local-manual.php
@@ -44,7 +44,8 @@ EventLoop::delay(1, static function () use ($logger) {
     $logger->log('Initializing...');
 
     $suspension = EventLoop::getSuspension();
-    EventLoop::delay(1, static fn () => $suspension->resume());
+    $continuation = $suspension->getContinuation();
+    EventLoop::delay(1, static fn () => $continuation->resume());
     $suspension->suspend();
 
     $logger->log('Done.');
@@ -62,7 +63,8 @@ EventLoop::delay(1, static function () use ($logger) {
     $logger->log('Initializing...');
 
     $suspension = EventLoop::getSuspension();
-    EventLoop::delay(1, static fn () => $suspension->resume());
+    $continuation = $suspension->getContinuation();
+    EventLoop::delay(1, static fn () => $continuation->resume());
     $suspension->suspend();
 
     $logger->log('Done.');
@@ -73,7 +75,8 @@ EventLoop::delay(1, static function () use ($logger) {
 $logger->log('Initializing...');
 
 $suspension = EventLoop::getSuspension();
-EventLoop::delay(3, static fn () => $suspension->resume());
+$continuation = $suspension->getContinuation();
+EventLoop::delay(3, static fn () => $continuation->resume());
 $suspension->suspend();
 
 $logger->log('Done.');

--- a/examples/http-client-suspension.php
+++ b/examples/http-client-suspension.php
@@ -7,6 +7,7 @@ require __DIR__ . '/../vendor/autoload.php';
 function fetch(string $url): string
 {
     $suspension = EventLoop::getSuspension();
+    $continuation = $suspension->getContinuation();
 
     $parsedUrl = \parse_url($url);
     if (!isset($parsedUrl['host'], $parsedUrl['path'])) {
@@ -30,7 +31,7 @@ function fetch(string $url): string
     \stream_set_blocking($stream, false);
 
     // wait for connection success/error
-    $watcher = EventLoop::onWritable($stream, fn () => $suspension->resume());
+    $watcher = EventLoop::onWritable($stream, fn () => $continuation->resume());
     $suspension->suspend();
     EventLoop::cancel($watcher);
 
@@ -40,7 +41,7 @@ function fetch(string $url): string
     $buffer = '';
 
     // wait for HTTP response
-    $watcher = EventLoop::onReadable($stream, fn () => $suspension->resume());
+    $watcher = EventLoop::onReadable($stream, fn () => $continuation->resume());
 
     do {
         $suspension->suspend();

--- a/examples/invalid-callback-return.php
+++ b/examples/invalid-callback-return.php
@@ -8,13 +8,14 @@ use Revolt\EventLoop;
 print "Press Ctrl+C to exit..." . PHP_EOL;
 
 $suspension = EventLoop::getSuspension();
+$continuation = $suspension->getContinuation();
 
-EventLoop::onSignal(\SIGINT, function (string $watcherId) use ($suspension) {
+EventLoop::onSignal(\SIGINT, function (string $watcherId) use ($continuation) {
     EventLoop::cancel($watcherId);
 
     print "Caught SIGINT, exiting..." . PHP_EOL;
 
-    $suspension->resume();
+    $continuation->resume();
 
     return new \stdClass();
 });

--- a/examples/stdin-timeout.php
+++ b/examples/stdin-timeout.php
@@ -13,18 +13,19 @@ if (\stream_set_blocking(STDIN, false) !== true) {
 print "Write something and hit enter" . PHP_EOL;
 
 $suspension = EventLoop::getSuspension();
+$continuation = $suspension->getContinuation();
 
-$readWatcher = EventLoop::onReadable(STDIN, function ($watcherId, $stream) use ($suspension) {
+$readWatcher = EventLoop::onReadable(STDIN, function ($watcherId, $stream) use ($continuation) {
     EventLoop::cancel($watcherId);
 
     $chunk = \fread($stream, 8192);
 
     print "Read " . \strlen($chunk) . " bytes" . PHP_EOL;
 
-    $suspension->resume();
+    $continuation->resume();
 });
 
-$timeoutWatcher = EventLoop::delay(5000, fn () => $suspension->resume());
+$timeoutWatcher = EventLoop::delay(5, fn () => $continuation->resume());
 
 $suspension->suspend();
 

--- a/examples/stdin.php
+++ b/examples/stdin.php
@@ -13,15 +13,16 @@ if (\stream_set_blocking(STDIN, false) !== true) {
 print "Write something and hit enter" . PHP_EOL;
 
 $suspension = EventLoop::getSuspension();
+$continuation = $suspension->getContinuation();
 
-EventLoop::onReadable(STDIN, function ($watcherId, $stream) use ($suspension) {
+EventLoop::onReadable(STDIN, function ($watcherId, $stream) use ($continuation) {
     EventLoop::cancel($watcherId);
 
     $chunk = \fread($stream, 8192);
 
     print "Read " . \strlen($chunk) . " bytes" . PHP_EOL;
 
-    $suspension->resume();
+    $continuation->resume();
 });
 
 $suspension->suspend();

--- a/examples/timers.php
+++ b/examples/timers.php
@@ -6,16 +6,17 @@ require __DIR__ . '/../vendor/autoload.php';
 use Revolt\EventLoop;
 
 $suspension = EventLoop::getSuspension();
+$continuation = $suspension->getContinuation();
 
 $repeatWatcher = EventLoop::repeat(1, function () {
     print "++ Executing watcher created by Loop::repeat()" . PHP_EOL;
 });
 
-EventLoop::delay(5, function () use ($suspension, $repeatWatcher) {
+EventLoop::delay(5, function () use ($continuation, $repeatWatcher) {
     print "++ Executing watcher created by Loop::delay()" . PHP_EOL;
 
     EventLoop::cancel($repeatWatcher);
-    $suspension->resume();
+    $continuation->resume();
 
     print "++ Executed after script ended" . PHP_EOL;
 });

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -370,21 +370,6 @@ final class EventLoop
     }
 
     /**
-     * Returns an object used to suspend and resume execution of the current fiber or {main}.
-     *
-     * Calls from the same fiber will return the same suspension object.
-     *
-     * @return Suspension
-     *
-     * @deprecated This old name is only kept temporarily to allow smooth transitions from 0.1 to 0.2 and will be
-     *     removed at a later point.
-     */
-    public static function createSuspension(): Suspension
-    {
-        return self::getDriver()->getSuspension();
-    }
-
-    /**
      * Run the event loop.
      *
      * This function may only be called from {main}, that is, not within a fiber.

--- a/src/EventLoop/Continuation.php
+++ b/src/EventLoop/Continuation.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Revolt\EventLoop;
+
+/**
+ * Should be accessed from {@see Suspension::getContinuation()}. This object is used to resume a coroutine that is
+ * suspended with {@see Suspension::suspend()}.
+ *
+ * @template T
+ */
+interface Continuation
+{
+    /**
+     * @param T $value
+     *
+     * @return void
+     */
+    public function resume(mixed $value = null): void;
+
+    public function throw(\Throwable $throwable): void;
+}

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -2,6 +2,7 @@
 
 namespace Revolt\EventLoop\Internal;
 
+use Revolt\EventLoop\Continuation;
 use Revolt\EventLoop\Driver;
 use Revolt\EventLoop\FiberLocal;
 use Revolt\EventLoop\InvalidCallbackError;
@@ -311,7 +312,10 @@ abstract class AbstractDriver implements Driver
             $this->runCallback,
             $this->queueCallback,
             $this->interruptCallback,
-            $this->suspensions
+            new SuspensionState(
+                $fiber,
+                \WeakReference::create($this->suspensions),
+            ),
         );
     }
 

--- a/src/EventLoop/Internal/DriverContinuation.php
+++ b/src/EventLoop/Internal/DriverContinuation.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Revolt\EventLoop\Internal;
+
+use Revolt\EventLoop\Continuation;
+use Revolt\EventLoop\Suspension;
+
+/**
+ * @internal
+ *
+ * @template T
+ * @implements Suspension<T>
+ */
+final class DriverContinuation implements Continuation
+{
+    private SuspensionState $state;
+
+    private \Closure $queue;
+
+    private \Closure $interrupt;
+
+    /**
+     * @param \Closure $queue
+     * @param \Closure $interrupt
+     *
+     * @internal
+     */
+    public function __construct(\Closure $queue, \Closure $interrupt, SuspensionState $state)
+    {
+        $this->queue = $queue;
+        $this->interrupt = $interrupt;
+        $this->state = $state;
+
+        // Add reference to fiber while this object exists.
+        $this->state->addReference();
+    }
+
+    public function __destruct()
+    {
+        // Remove reference to fiber when this object is destroyed.
+        $this->state->deleteReference();
+    }
+
+    public function isPending(): bool
+    {
+        return $this->state->pending;
+    }
+
+    public function resume(mixed $value = null): void
+    {
+        if (!$this->state->pending) {
+            throw $this->state->fiberError ?? new \Error('Must call suspend() before calling resume()');
+        }
+
+        $this->state->pending = false;
+
+        if ($this->state->fiber) {
+            ($this->queue)(\Closure::fromCallable([$this->state->fiber, 'resume']), $value);
+        } else {
+            // Suspend event loop fiber to {main}.
+            ($this->interrupt)(static fn () => $value);
+        }
+    }
+
+    public function throw(\Throwable $throwable): void
+    {
+        if (!$this->state->pending) {
+            throw $this->state->fiberError ?? new \Error('Must call suspend() before calling throw()');
+        }
+
+        $this->state->pending = false;
+
+        if ($this->state->fiber) {
+            ($this->queue)(\Closure::fromCallable([$this->state->fiber, 'throw']), $throwable);
+        } else {
+            // Suspend event loop fiber to {main}.
+            ($this->interrupt)(static fn () => throw $throwable);
+        }
+    }
+}

--- a/src/EventLoop/Internal/SuspensionState.php
+++ b/src/EventLoop/Internal/SuspensionState.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Revolt\EventLoop\Internal;
+
+class SuspensionState
+{
+    public bool $pending = false;
+
+    public ?\Fiber $fiber = null;
+
+    public ?\WeakReference $reference;
+
+    public \FiberError $fiberError;
+
+    private int $refCount = 0;
+
+    public function __construct(
+        ?\Fiber $fiber,
+        public \WeakReference $suspensions,
+    ) {
+        $this->reference = $fiber ? \WeakReference::create($fiber) : null;
+    }
+
+    public function addReference(): void
+    {
+        if (!$this->refCount++) {
+            $this->fiber = $this->reference?->get();
+        }
+    }
+
+    public function deleteReference(): void
+    {
+        \assert($this->refCount > 0);
+
+        if (!--$this->refCount) {
+            $this->fiber = null;
+        }
+    }
+}

--- a/src/EventLoop/Suspension.php
+++ b/src/EventLoop/Suspension.php
@@ -9,10 +9,11 @@ namespace Revolt\EventLoop;
  *
  * ```php
  * $suspension = EventLoop::getSuspension();
+ * $continuation = $suspension->getContinuation();
  *
  * $promise->then(
- *     fn (mixed $value) => $suspension->resume($value),
- *     fn (Throwable $error) => $suspension->throw($error)
+ *     fn (mixed $value) => $continuation->resume($value),
+ *     fn (Throwable $error) => $continuation->throw($error)
  * );
  *
  * $suspension->suspend();
@@ -23,16 +24,12 @@ namespace Revolt\EventLoop;
 interface Suspension
 {
     /**
-     * @param T $value
-     *
-     * @return void
-     */
-    public function resume(mixed $value = null): void;
-
-    /**
      * @return T
      */
     public function suspend(): mixed;
 
-    public function throw(\Throwable $throwable): void;
+    /**
+     * @return Continuation<T>
+     */
+    public function getContinuation(): Continuation;
 }


### PR DESCRIPTION
This PR adds a `Continuation` abstraction to `Suspension` to help avoid accidental memory leaks. If all `Continuation` objects associated with a `Suspension` are destroyed, the associated fiber is destroyed.