### PR TITLE
Require PHP 8.1 and use features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ jobs:
       matrix:
         include:
           - operating-system: 'ubuntu-latest'
-            php-version: '8.0'
-            composer-flags: '--ignore-platform-req=php'
-          - operating-system: 'ubuntu-latest'
             php-version: '8.1'
             composer-flags: '--ignore-platform-req=php'
 
@@ -40,7 +37,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: fiber-amphp/ext-fiber@master, uv-amphp/ext-uv@master, ev-beta, event, :xdebug
+          extensions: uv-amphp/ext-uv@master, ev-beta, event, :xdebug
 
       - name: Get Composer cache directory
         id: composer-cache

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Different (strongly) opinionated libraries can be built on top of it and both Am
 ## Installation
 
 It may surprise people to learn that the PHP standard library already has everything we need to write event-driven and non-blocking applications.
-This package can be installed as a [Composer](https://getcomposer.org/) dependency on PHP 8 and later.
-PHP 8.1 ships with fibers built-in, but users on PHP 8.0 can install [`ext-fiber`](https://github.com/amphp/ext-fiber) with almost identical behavior.
+This package can be installed as a [Composer](https://getcomposer.org/) dependency on PHP 8.1 and later.
 
 ```bash
 composer require revolt/event-loop

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         }
     ],
     "require": {
-        "php": ">=8.0.7"
+        "php": ">=8.1"
     },
     "require-dev": {
         "ext-json": "*",

--- a/src/EventLoop/Driver/EvDriver.php
+++ b/src/EventLoop/Driver/EvDriver.php
@@ -27,11 +27,11 @@ final class EvDriver extends AbstractDriver
     /** @var \EvWatcher[] */
     private array $events = [];
 
-    private \Closure $ioCallback;
+    private readonly \Closure $ioCallback;
 
-    private \Closure $timerCallback;
+    private readonly \Closure $timerCallback;
 
-    private \Closure $signalCallback;
+    private readonly \Closure $signalCallback;
 
     /** @var \EvSignal[] */
     private array $signals = [];

--- a/src/EventLoop/Driver/EventDriver.php
+++ b/src/EventLoop/Driver/EventDriver.php
@@ -25,9 +25,9 @@ final class EventDriver extends AbstractDriver
     private \EventBase $handle;
     /** @var \Event[] */
     private array $events = [];
-    private \Closure $ioCallback;
-    private \Closure $timerCallback;
-    private \Closure $signalCallback;
+    private readonly \Closure $ioCallback;
+    private readonly \Closure $timerCallback;
+    private readonly \Closure $signalCallback;
     private array $signals = [];
 
     public function __construct()

--- a/src/EventLoop/Driver/StreamSelectDriver.php
+++ b/src/EventLoop/Driver/StreamSelectDriver.php
@@ -167,7 +167,9 @@ final class StreamSelectDriver extends AbstractDriver
             } elseif ($callback instanceof SignalCallback) {
                 if (!isset($this->signalCallbacks[$callback->signal])) {
                     \set_error_handler(static function (int $errno, string $errstr): bool {
-                        throw new \Error(\sprintf("Failed to register signal handler; Errno: %d; %s", $errno, $errstr));
+                        throw new UnsupportedFeatureException(
+                            \sprintf("Failed to register signal handler; Errno: %d; %s", $errno, $errstr)
+                        );
                     });
 
                     // Avoid bug in Psalm handling of first-class callables by assigning to a temp variable.

--- a/src/EventLoop/Driver/StreamSelectDriver.php
+++ b/src/EventLoop/Driver/StreamSelectDriver.php
@@ -27,17 +27,17 @@ final class StreamSelectDriver extends AbstractDriver
     /** @var StreamWritableCallback[][] */
     private array $writeCallbacks = [];
 
-    private TimerQueue $timerQueue;
+    private readonly TimerQueue $timerQueue;
 
     /** @var SignalCallback[][] */
     private array $signalCallbacks = [];
 
     /** @var \SplQueue<int> */
-    private \SplQueue $signalQueue;
+    private readonly \SplQueue $signalQueue;
 
     private bool $signalHandling;
 
-    private \Closure $streamSelectErrorHandler;
+    private readonly \Closure $streamSelectErrorHandler;
 
     private bool $streamSelectIgnoreResult = false;
 
@@ -166,12 +166,17 @@ final class StreamSelectDriver extends AbstractDriver
                 $this->timerQueue->insert($callback);
             } elseif ($callback instanceof SignalCallback) {
                 if (!isset($this->signalCallbacks[$callback->signal])) {
-                    if (!@\pcntl_signal($callback->signal, \Closure::fromCallable([$this, 'handleSignal']))) {
-                        $message = "Failed to register signal handler";
-                        if ($error = \error_get_last()) {
-                            $message .= \sprintf("; Errno: %d; %s", $error["type"], $error["message"]);
-                        }
-                        throw new \Error($message);
+                    \set_error_handler(static function (int $errno, string $errstr): bool {
+                        throw new \Error(\sprintf("Failed to register signal handler; Errno: %d; %s", $errno, $errstr));
+                    });
+
+                    // Avoid bug in Psalm handling of first-class callables by assigning to a temp variable.
+                    $handler = $this->handleSignal(...);
+
+                    try {
+                        \pcntl_signal($callback->signal, $handler);
+                    } finally {
+                        \restore_error_handler();
                     }
                 }
 
@@ -209,7 +214,12 @@ final class StreamSelectDriver extends AbstractDriver
 
                 if (empty($this->signalCallbacks[$callback->signal])) {
                     unset($this->signalCallbacks[$callback->signal]);
-                    @\pcntl_signal($callback->signal, \SIG_DFL);
+                    \set_error_handler(static fn () => true);
+                    try {
+                        \pcntl_signal($callback->signal, \SIG_DFL);
+                    } finally {
+                        \restore_error_handler();
+                    }
                 }
             }
         } else {

--- a/src/EventLoop/Driver/TracingDriver.php
+++ b/src/EventLoop/Driver/TracingDriver.php
@@ -8,7 +8,7 @@ use Revolt\EventLoop\Suspension;
 
 final class TracingDriver implements Driver
 {
-    private Driver $driver;
+    private readonly Driver $driver;
 
     /** @var true[] */
     private array $enabledCallbacks = [];

--- a/src/EventLoop/Driver/UvDriver.php
+++ b/src/EventLoop/Driver/UvDriver.php
@@ -25,9 +25,9 @@ final class UvDriver extends AbstractDriver
     private array $callbacks = [];
     /** @var resource[] */
     private array $streams = [];
-    private \Closure $ioCallback;
-    private \Closure $timerCallback;
-    private \Closure $signalCallback;
+    private readonly \Closure $ioCallback;
+    private readonly \Closure $timerCallback;
+    private readonly \Closure $signalCallback;
 
     public function __construct()
     {

--- a/src/EventLoop/FiberLocal.php
+++ b/src/EventLoop/FiberLocal.php
@@ -47,7 +47,7 @@ final class FiberLocal
     /**
      * @param \Closure():T $initializer
      */
-    public function __construct(private \Closure $initializer)
+    public function __construct(private readonly \Closure $initializer)
     {
     }
 

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -26,7 +26,7 @@ abstract class AbstractDriver implements Driver
     private \Fiber $fiber;
 
     private \Fiber $callbackFiber;
-    private readonly \Closure $errorCallback;
+    private \Closure $errorCallback;
 
     /** @var DriverCallback[] */
     private array $callbacks = [];
@@ -56,7 +56,7 @@ abstract class AbstractDriver implements Driver
     private bool $idle = false;
     private bool $stopped = false;
 
-    private readonly \WeakMap $suspensions;
+    private \WeakMap $suspensions;
 
     public function __construct()
     {

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -26,7 +26,7 @@ abstract class AbstractDriver implements Driver
     private \Fiber $fiber;
 
     private \Fiber $callbackFiber;
-    private \Closure $errorCallback;
+    private readonly \Closure $errorCallback;
 
     /** @var DriverCallback[] */
     private array $callbacks = [];
@@ -45,7 +45,7 @@ abstract class AbstractDriver implements Driver
     private readonly \Closure $queueCallback;
     private readonly \Closure $runCallback;
 
-    private \stdClass $internalSuspensionMarker;
+    private readonly \stdClass $internalSuspensionMarker;
 
     /** @var \SplQueue<array{\Closure, array}> */
     private readonly \SplQueue $microtaskQueue;
@@ -56,7 +56,7 @@ abstract class AbstractDriver implements Driver
     private bool $idle = false;
     private bool $stopped = false;
 
-    private \WeakMap $suspensions;
+    private readonly \WeakMap $suspensions;
 
     public function __construct()
     {

--- a/src/EventLoop/Internal/DriverCallback.php
+++ b/src/EventLoop/Internal/DriverCallback.php
@@ -13,21 +13,16 @@ abstract class DriverCallback
 
     public bool $referenced = true;
 
-    public \Closure $closure;
-
     public function __construct(
-        public string $id,
-        \Closure $closure
+        public readonly string $id,
+        public readonly \Closure $closure
     ) {
-        $this->closure = $closure;
     }
 
     /**
      * @param string $property
-     *
-     * @psalm-return no-return
      */
-    public function __get(string $property): void
+    public function __get(string $property): never
     {
         throw new \Error("Unknown property '${property}'");
     }
@@ -35,10 +30,8 @@ abstract class DriverCallback
     /**
      * @param string $property
      * @param mixed  $value
-     *
-     * @psalm-return no-return
      */
-    public function __set(string $property, mixed $value): void
+    public function __set(string $property, mixed $value): never
     {
         throw new \Error("Unknown property '${property}'");
     }

--- a/src/EventLoop/Internal/DriverSuspension.php
+++ b/src/EventLoop/Internal/DriverSuspension.php
@@ -15,19 +15,19 @@ final class DriverSuspension implements Suspension
     private ?\Fiber $suspendedFiber = null;
 
     /** @var \WeakReference<\Fiber>|null */
-    private ?\WeakReference $fiberRef;
+    private readonly ?\WeakReference $fiberRef;
 
     private ?\FiberError $fiberError = null;
 
-    private \Closure $run;
+    private readonly \Closure $run;
 
-    private \Closure $queue;
+    private readonly \Closure $queue;
 
-    private \Closure $interrupt;
+    private readonly \Closure $interrupt;
 
     private bool $pending = false;
 
-    private \WeakReference $suspensions;
+    private readonly \WeakReference $suspensions;
 
     /**
      * @param \Closure $run
@@ -59,7 +59,7 @@ final class DriverSuspension implements Suspension
         $fiber = $this->fiberRef?->get();
 
         if ($fiber) {
-            ($this->queue)(\Closure::fromCallable([$fiber, 'resume']), $value);
+            ($this->queue)($fiber->resume(...), $value);
         } else {
             // Suspend event loop fiber to {main}.
             ($this->interrupt)(static fn () => $value);
@@ -139,7 +139,7 @@ final class DriverSuspension implements Suspension
         $fiber = $this->fiberRef?->get();
 
         if ($fiber) {
-            ($this->queue)(\Closure::fromCallable([$fiber, 'throw']), $throwable);
+            ($this->queue)($fiber->throw(...), $throwable);
         } else {
             // Suspend event loop fiber to {main}.
             ($this->interrupt)(static fn () => throw $throwable);

--- a/src/EventLoop/Internal/SignalCallback.php
+++ b/src/EventLoop/Internal/SignalCallback.php
@@ -8,7 +8,7 @@ final class SignalCallback extends DriverCallback
     public function __construct(
         string $id,
         \Closure $closure,
-        public int $signal
+        public readonly int $signal
     ) {
         parent::__construct($id, $closure);
     }

--- a/src/EventLoop/Internal/StreamCallback.php
+++ b/src/EventLoop/Internal/StreamCallback.php
@@ -11,7 +11,7 @@ abstract class StreamCallback extends DriverCallback
     public function __construct(
         string $id,
         \Closure $closure,
-        public mixed $stream
+        public readonly mixed $stream
     ) {
         parent::__construct($id, $closure);
     }

--- a/src/EventLoop/Internal/TimerCallback.php
+++ b/src/EventLoop/Internal/TimerCallback.php
@@ -7,10 +7,10 @@ final class TimerCallback extends DriverCallback
 {
     public function __construct(
         string $id,
-        public float $interval,
+        public readonly float $interval,
         \Closure $callback,
         public float $expiration,
-        public bool $repeat = false
+        public readonly bool $repeat = false
     ) {
         parent::__construct($id, $callback);
     }

--- a/src/EventLoop/InvalidCallbackError.php
+++ b/src/EventLoop/InvalidCallbackError.php
@@ -32,10 +32,10 @@ final class InvalidCallbackError extends \Error
     }
 
     /** @var string */
-    private string $rawMessage;
+    private readonly string $rawMessage;
 
     /** @var string */
-    private string $callbackId;
+    private readonly string $callbackId;
 
     /** @var string[] */
     private array $info = [];

--- a/test/Driver/DriverTest.php
+++ b/test/Driver/DriverTest.php
@@ -901,11 +901,11 @@ abstract class DriverTest extends TestCase
             $increment++;
         });
         $this->loop->disable($callbackId);
-        $this->loop->delay(0.005, \Closure::fromCallable([$this->loop, "stop"]));
+        $this->loop->delay(0.005, $this->loop->stop(...));
         $this->loop->run();
         self::assertSame(0, $increment);
         $this->loop->enable($callbackId);
-        $this->loop->delay(0.005, \Closure::fromCallable([$this->loop, "stop"]));
+        $this->loop->delay(0.005, $this->loop->stop(...));
         $this->loop->run();
         self::assertSame(1, $increment);
     }
@@ -914,7 +914,7 @@ abstract class DriverTest extends TestCase
     {
         $increment = 0;
         $this->start(function (Driver $loop) use (&$increment): void {
-            $loop->defer(\Closure::fromCallable([$loop, "stop"]));
+            $loop->defer($loop->stop(...));
             $loop->run();
 
             $loop->defer(function () use (&$increment, $loop): void {
@@ -979,7 +979,7 @@ abstract class DriverTest extends TestCase
             });
 
             $loop->disable($callbackId);
-            $loop->delay(0.005, \Closure::fromCallable([$loop, "stop"]));
+            $loop->delay(0.005, $loop->stop(...));
 
             $this->assertSame(0, $increment);
         });
@@ -992,7 +992,7 @@ abstract class DriverTest extends TestCase
             $loop->defer(function () use (&$increment): void {
                 $increment++;
             });
-            $loop->defer(\Closure::fromCallable([$loop, "stop"]));
+            $loop->defer($loop->stop(...));
         });
         self::assertSame(1, $increment);
     }
@@ -1007,7 +1007,7 @@ abstract class DriverTest extends TestCase
                     $increment++;
                 });
             });
-            $loop->defer(\Closure::fromCallable([$loop, "stop"]));
+            $loop->defer($loop->stop(...));
         });
         self::assertSame(1, $increment);
     }
@@ -1177,7 +1177,7 @@ abstract class DriverTest extends TestCase
                 $invoked = true;
             });
 
-            $loop->delay(0.005, \Closure::fromCallable([$loop, "stop"]));
+            $loop->delay(0.005, $loop->stop(...));
         });
 
         self::assertTrue($invoked);
@@ -1191,7 +1191,7 @@ abstract class DriverTest extends TestCase
                 $flag = true;
                 $loop->stop();
             });
-            $loop->delay(0.005, \Closure::fromCallable([$loop, "stop"]));
+            $loop->delay(0.005, $loop->stop(...));
         });
         self::assertTrue($flag);
     }
@@ -1204,7 +1204,7 @@ abstract class DriverTest extends TestCase
                 $increment++;
             });
             $loop->disable($callbackId);
-            $loop->delay(0.005, \Closure::fromCallable([$loop, "stop"]));
+            $loop->delay(0.005, $loop->stop(...));
         });
         self::assertSame(0, $increment);
     }
@@ -1234,7 +1234,7 @@ abstract class DriverTest extends TestCase
                 $loop->onWritable(STDOUT, function () {
                     throw new \RuntimeException();
                 });
-                $loop->delay(0.005, \Closure::fromCallable([$loop, "stop"]));
+                $loop->delay(0.005, $loop->stop(...));
             });
         } catch (UncaughtThrowable $e) {
             throw $e->getPrevious();
@@ -1319,7 +1319,7 @@ abstract class DriverTest extends TestCase
                     $this->fail("Timer was executed despite stopped loop");
                 });
             });
-            $loop->defer(\Closure::fromCallable([$loop, "stop"]));
+            $loop->defer($loop->stop(...));
         });
         self::assertGreaterThan(\microtime(1), $t + 0.1);
     }
@@ -1327,7 +1327,7 @@ abstract class DriverTest extends TestCase
     public function testDeferEnabledInNextTick(): void
     {
         $tick = function () {
-            $this->loop->defer(\Closure::fromCallable([$this->loop, "stop"]));
+            $this->loop->defer($this->loop->stop(...));
             $this->loop->run();
         };
 


### PR DESCRIPTION
A couple somewhat tangential changes:
- Switched to using a custom error handler instead of the `@` operator when calling `pcntl_signal` in `StreamSelectDriver`.
- Removed the fiber check in the constructor of `AbstractDriver`, since the file won't parse in PHP versions below 8.1, it seemed pointless to retain it.