### PR TITLE
Rethrow `UncaughtThrowable` thrown by callbacks/error handler without wrapping

### DIFF
--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -394,7 +394,9 @@ abstract class AbstractDriver implements Driver
     {
         if ($this->errorHandler === null) {
             // Explicitly override the previous interrupt if it exists in this case, hiding the exception is worse
-            $this->interrupt = static fn () => throw UncaughtThrowable::throwingCallback($closure, $exception);
+            $this->interrupt = static fn () => $exception instanceof UncaughtThrowable
+                ? throw $exception
+                : throw UncaughtThrowable::throwingCallback($closure, $exception);
             return;
         }
 
@@ -624,7 +626,9 @@ abstract class AbstractDriver implements Driver
                 $errorHandler($exception);
             } catch (\Throwable $exception) {
                 $this->setInterrupt(
-                    static fn () => throw UncaughtThrowable::throwingErrorHandler($errorHandler, $exception)
+                    static fn () => $exception instanceof UncaughtThrowable
+                        ? throw $exception
+                        : throw UncaughtThrowable::throwingErrorHandler($errorHandler, $exception)
                 );
             }
         };

--- a/test/Driver/DriverTest.php
+++ b/test/Driver/DriverTest.php
@@ -1120,6 +1120,29 @@ abstract class DriverTest extends TestCase
         }
     }
 
+    public function testUncaughtThrowableInstanceIsRethrownAsIs(): void
+    {
+        $error = UncaughtThrowable::throwingCallback(static fn () => null, new \Error("Test error"));
+        $this->loop->queue(static fn () => throw $error);
+        try {
+            $this->loop->getSuspension()->suspend();
+        } catch (UncaughtThrowable $t) {
+            self::assertSame($error, $t);
+        }
+    }
+
+    public function testUncaughtThrowableInstanceIsRethrownAsIsFromErrorHandler(): void
+    {
+        $error = UncaughtThrowable::throwingErrorHandler(static fn () => null, new \Error("Test error"));
+        $this->loop->setErrorHandler(static fn () => throw $error);
+        $this->loop->queue(static fn () => throw new \Error());
+        try {
+            $this->loop->getSuspension()->suspend();
+        } catch (UncaughtThrowable $t) {
+            self::assertSame($error, $t);
+        }
+    }
+
     public function testOnSignalCallback(): void
     {
         $this->checkForSignalCapability();


### PR DESCRIPTION
Useful for driver decorators that wrap provided callbacks in their own callbacks; allows reporting the original callback as error cause.