### PR TITLE
Implement custom FiberFactory interface

### DIFF
--- a/src/EventLoop/DefaultFiberFactory.php
+++ b/src/EventLoop/DefaultFiberFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Revolt\EventLoop;
+
+final class DefaultFiberFactory implements FiberFactory
+{
+    /**
+     * Creates a new fiber instance.
+     *
+     * @param callable $callable The callable to invoke when starting the fiber.
+     *
+     * @return \Fiber
+     */
+    public function create(callable $callback): \Fiber
+    {
+        return new \Fiber($callback);
+    }
+}

--- a/src/EventLoop/Driver/EvDriver.php
+++ b/src/EventLoop/Driver/EvDriver.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 namespace Revolt\EventLoop\Driver;
 
+use Revolt\EventLoop\FiberFactory;
 use Revolt\EventLoop\Internal\AbstractDriver;
 use Revolt\EventLoop\Internal\DriverCallback;
 use Revolt\EventLoop\Internal\SignalCallback;
@@ -38,9 +39,9 @@ final class EvDriver extends AbstractDriver
     /** @var array<string, \EvSignal> */
     private array $signals = [];
 
-    public function __construct()
+    public function __construct(?FiberFactory $fiberFactory = null)
     {
-        parent::__construct();
+        parent::__construct($fiberFactory);
 
         $this->handle = new \EvLoop();
 

--- a/src/EventLoop/Driver/EventDriver.php
+++ b/src/EventLoop/Driver/EventDriver.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 namespace Revolt\EventLoop\Driver;
 
+use Revolt\EventLoop\FiberFactory;
 use Revolt\EventLoop\Internal\AbstractDriver;
 use Revolt\EventLoop\Internal\DriverCallback;
 use Revolt\EventLoop\Internal\SignalCallback;
@@ -34,9 +35,9 @@ final class EventDriver extends AbstractDriver
     /** @var array<string, \Event> */
     private array $signals = [];
 
-    public function __construct()
+    public function __construct(?FiberFactory $fiberFactory = null)
     {
-        parent::__construct();
+        parent::__construct($fiberFactory);
 
         /** @psalm-suppress TooFewArguments https://github.com/JetBrains/phpstorm-stubs/pull/763 */
         $this->handle = new \EventBase();

--- a/src/EventLoop/Driver/StreamSelectDriver.php
+++ b/src/EventLoop/Driver/StreamSelectDriver.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 namespace Revolt\EventLoop\Driver;
 
+use Revolt\EventLoop\FiberFactory;
 use Revolt\EventLoop\Internal\AbstractDriver;
 use Revolt\EventLoop\Internal\DriverCallback;
 use Revolt\EventLoop\Internal\SignalCallback;
@@ -43,9 +44,9 @@ final class StreamSelectDriver extends AbstractDriver
 
     private bool $streamSelectIgnoreResult = false;
 
-    public function __construct()
+    public function __construct(?FiberFactory $fiberFactory = null)
     {
-        parent::__construct();
+        parent::__construct($fiberFactory);
 
         $this->signalQueue = new \SplQueue();
         $this->timerQueue = new TimerQueue();

--- a/src/EventLoop/Driver/UvDriver.php
+++ b/src/EventLoop/Driver/UvDriver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Revolt\EventLoop\Driver;
 
+use Revolt\EventLoop\FiberFactory;
 use Revolt\EventLoop\Internal\AbstractDriver;
 use Revolt\EventLoop\Internal\DriverCallback;
 use Revolt\EventLoop\Internal\SignalCallback;
@@ -31,9 +32,9 @@ final class UvDriver extends AbstractDriver
     private readonly \Closure $timerCallback;
     private readonly \Closure $signalCallback;
 
-    public function __construct()
+    public function __construct(?FiberFactory $fiberFactory = null)
     {
-        parent::__construct();
+        parent::__construct($fiberFactory);
 
         $this->handle = \uv_loop_new();
 

--- a/src/EventLoop/FiberFactory.php
+++ b/src/EventLoop/FiberFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Revolt\EventLoop;
+
+interface FiberFactory
+{
+    /**
+     * Creates a new fiber instance.
+     *
+     * @param callable $callable The callable to invoke when starting the fiber.
+     *
+     * @return \Fiber
+     */
+    public function create(callable $callback): \Fiber;
+}

--- a/src/EventLoop/FiberLocal.php
+++ b/src/EventLoop/FiberLocal.php
@@ -13,8 +13,8 @@ namespace Revolt\EventLoop;
  */
 final class FiberLocal
 {
-    /** @var \Fiber|null Dummy fiber for {main} */
-    private static ?\Fiber $mainFiber = null;
+    /** @var object|null Dummy object for {main} */
+    private static ?object $dummyMain = null;
     private static ?\WeakMap $localStorage = null;
 
     public static function clear(): void
@@ -23,7 +23,7 @@ final class FiberLocal
             return;
         }
 
-        $fiber = \Fiber::getCurrent() ?? self::$mainFiber;
+        $fiber = \Fiber::getCurrent() ?? self::$dummyMain;
 
         if ($fiber === null) {
             return;
@@ -37,9 +37,7 @@ final class FiberLocal
         $fiber = \Fiber::getCurrent();
 
         if ($fiber === null) {
-            $fiber = self::$mainFiber ??= new \Fiber(static function (): void {
-                // dummy fiber for main, as we need some object for the WeakMap
-            });
+            $fiber = self::$dummyMain ??= new class {};
         }
 
         $localStorage = self::$localStorage ??= new \WeakMap();

--- a/src/EventLoop/FiberLocal.php
+++ b/src/EventLoop/FiberLocal.php
@@ -37,7 +37,8 @@ final class FiberLocal
         $fiber = \Fiber::getCurrent();
 
         if ($fiber === null) {
-            $fiber = self::$dummyMain ??= new class {};
+            $fiber = self::$dummyMain ??= new class () {
+            };
         }
 
         $localStorage = self::$localStorage ??= new \WeakMap();

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -414,7 +414,7 @@ abstract class AbstractDriver implements Driver
         /** @noinspection PhpUnhandledExceptionInspection */
         $yielded = $this->errorFiber->isStarted() ? $this->errorFiber->resume($exception) : $this->errorFiber->start($exception);
 
-        if ($$yielded !== $this->internalSuspensionMarker) {
+        if ($yielded !== $this->internalSuspensionMarker) {
             $this->createErrorFiber();
         }
     }

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -639,9 +639,11 @@ abstract class AbstractDriver implements Driver
         $this->errorFiber = new \Fiber(function (\Throwable $exception): void {
             do {
                 try {
+                    assert($this->errorHandler !== null);
                     ($this->errorHandler)($exception);
                 } catch (\Throwable $exception) {
                     $errorHandler = $this->errorHandler;
+                    assert($errorHandler !== null);
                     $this->interrupt = static fn () => $exception instanceof UncaughtThrowable
                         ? throw $exception
                         : throw UncaughtThrowable::throwingErrorHandler($errorHandler, $exception);

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -641,9 +641,10 @@ abstract class AbstractDriver implements Driver
                     $exception = Fiber::suspend($this->internalSuspensionMarker);
                     ($this->errorHandler)($exception);
                 } catch (\Throwable $exception) {
+                    $errorHandler = $this->errorHandler;
                     $this->interrupt = static fn () => $exception instanceof UncaughtThrowable
                         ? throw $exception
-                        : throw UncaughtThrowable::throwingErrorHandler($this->errorHandler, $exception);
+                        : throw UncaughtThrowable::throwingErrorHandler($errorHandler, $exception);
                 }
             } while (true);
         });

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -639,7 +639,6 @@ abstract class AbstractDriver implements Driver
         $this->errorFiber = new \Fiber(function (\Throwable $exception): void {
             do {
                 try {
-                    $exception ??= Fiber::suspend($this->internalSuspensionMarker);
                     ($this->errorHandler)($exception);
                 } catch (\Throwable $exception) {
                     $errorHandler = $this->errorHandler;
@@ -647,7 +646,7 @@ abstract class AbstractDriver implements Driver
                         ? throw $exception
                         : throw UncaughtThrowable::throwingErrorHandler($errorHandler, $exception);
                 }
-                $exception = null;
+                $exception = Fiber::suspend($this->internalSuspensionMarker);
             } while (true);
         });
     }

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -639,11 +639,11 @@ abstract class AbstractDriver implements Driver
         $this->errorFiber = new \Fiber(function (\Throwable $exception): void {
             do {
                 try {
-                    assert($this->errorHandler !== null);
+                    \assert($this->errorHandler !== null);
                     ($this->errorHandler)($exception);
                 } catch (\Throwable $exception) {
                     $errorHandler = $this->errorHandler;
-                    assert($errorHandler !== null);
+                    \assert($errorHandler !== null);
                     $this->interrupt = static fn () => $exception instanceof UncaughtThrowable
                         ? throw $exception
                         : throw UncaughtThrowable::throwingErrorHandler($errorHandler, $exception);

--- a/src/EventLoop/TracingFiberFactory.php
+++ b/src/EventLoop/TracingFiberFactory.php
@@ -37,6 +37,7 @@ final class TracingFiberFactory implements FiberFactory, Countable, IteratorAggr
     public function create(callable $callback): \Fiber
     {
         $f = $this->fiberFactory->create($callback);
+        /** @psalm-suppress InaccessibleProperty */
         $this->map[$f] = null;
         return $f;
     }

--- a/src/EventLoop/TracingFiberFactory.php
+++ b/src/EventLoop/TracingFiberFactory.php
@@ -18,10 +18,11 @@ final class TracingFiberFactory implements FiberFactory, Countable, IteratorAggr
     /**
      * @var \WeakMap<\Fiber, null>
      */
-    private \WeakMap $map;
+    private readonly \WeakMap $map;
 
-    public function __construct()
-    {
+    public function __construct(
+        private readonly FiberFactory $fiberFactory = new DefaultFiberFactory()
+    ) {
         /** @var \WeakMap<\Fiber, null> */
         $this->map = new \WeakMap();
     }
@@ -35,7 +36,7 @@ final class TracingFiberFactory implements FiberFactory, Countable, IteratorAggr
      */
     public function create(callable $callback): \Fiber
     {
-        $f = new \Fiber($callback);
+        $f = $this->fiberFactory->create($callback);
         $this->map[$f] = null;
         return $f;
     }

--- a/src/EventLoop/TracingFiberFactory.php
+++ b/src/EventLoop/TracingFiberFactory.php
@@ -51,7 +51,7 @@ final class TracingFiberFactory implements FiberFactory, Countable, IteratorAggr
     }
 
     /**
-     * Iterate over all currently running fibers.
+     * Iterate over all fibers currently in scope.
      *
      * @return Traversable<\Fiber, null>
      */

--- a/src/EventLoop/TracingFiberFactory.php
+++ b/src/EventLoop/TracingFiberFactory.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Revolt\EventLoop;
+
+use Countable;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * Fiber factory which collects all created fibers in a weak map.
+ *
+ * @implements IteratorAggregate<\Fiber, null>
+ */
+final class TracingFiberFactory implements FiberFactory, Countable, IteratorAggregate
+{
+    /**
+     * @var \WeakMap<\Fiber, null>
+     */
+    private \WeakMap $map;
+
+    public function __construct()
+    {
+        /** @var \WeakMap<\Fiber, null> */
+        $this->map = new \WeakMap();
+    }
+
+    /**
+     * Creates a new fiber instance.
+     *
+     * @param callable $callable The callable to invoke when starting the fiber.
+     *
+     * @return \Fiber
+     */
+    public function create(callable $callback): \Fiber
+    {
+        $f = new \Fiber($callback);
+        $this->map[$f] = null;
+        return $f;
+    }
+
+    /**
+     * Returns the number of running fibers.
+     *
+     * @return int
+     */
+    public function count(): int
+    {
+        return $this->map->count();
+    }
+
+    /**
+     * Iterate over all currently running fibers.
+     *
+     * @return Traversable<\Fiber, null>
+     */
+    public function getIterator(): Traversable
+    {
+        return $this->map->getIterator();
+    }
+}

--- a/test/Driver/TracingFiberFactoryTest.php
+++ b/test/Driver/TracingFiberFactoryTest.php
@@ -12,7 +12,7 @@ class TracingFiberFactoryTest extends StreamSelectDriverTest
     private static TracingFiberFactory $factory;
     public function getFactory(): callable
     {
-        self::$factory ??= new TracingFiberFactory;
+        self::$factory ??= new TracingFiberFactory();
         return static function (): StreamSelectDriver {
             return new StreamSelectDriver(self::$factory);
         };

--- a/test/Driver/TracingFiberFactoryTest.php
+++ b/test/Driver/TracingFiberFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Revolt\EventLoop\Driver;
+
+use Revolt\EventLoop\Driver;
+use Revolt\EventLoop\TracingFiberFactory;
+
+class TracingFiberFactoryTest extends StreamSelectDriverTest
+{
+    private static TracingFiberFactory $factory;
+    public function getFactory(): callable
+    {
+        self::$factory ??= new TracingFiberFactory;
+        return static function (): StreamSelectDriver {
+            return new StreamSelectDriver(self::$factory);
+        };
+    }
+
+    public function testNumberOfFibers(): void
+    {
+        self::assertEquals(2, self::$factory->count());
+        $this->start(static function (Driver $loop): void {
+            $loop->queue(static function () use ($loop) {
+                $suspension = $loop->getSuspension();
+                $loop->delay(1, $suspension->resume(...));
+                $suspension->suspend();
+            });
+            $loop->delay(0.5, function () {
+                self::assertEquals(3, self::$factory->count());
+            });
+        });
+        self::assertEquals(2, self::$factory->count());
+    }
+}


### PR DESCRIPTION
Create a FiberFactory interface and DefaultFiberFactory/TracingFiberFactory implementations, to allow to easily track the state of all running fibers, simplifying debugging/searching for fiber leaks.

I've also removed the logic that uselessly created a dummy fiber inside of FiberLocal, replacing it with a simple anonymous class instead (since the $localStorage WeakMap property won't be visible or usable from the outside anyway).