### PR TITLE
fix test of FD_SETSIZE

### DIFF
--- a/test/Driver/StreamSelectDriverTest.php
+++ b/test/Driver/StreamSelectDriverTest.php
@@ -60,6 +60,10 @@ class StreamSelectDriverTest extends DriverTest
 
     public function testTooLargeFileDescriptorSet(): void
     {
+        if (\stripos(PHP_OS, 'win') === 0) {
+            // win FD_SETSIZE not 1024
+            self::markTestSkipped('Skip on Windows');
+        }
         $sockets = [];
         $domain = \stripos(PHP_OS, 'win') === 0 ? STREAM_PF_INET : STREAM_PF_UNIX;
 

--- a/test/Driver/StreamSelectDriverTest.php
+++ b/test/Driver/StreamSelectDriverTest.php
@@ -64,11 +64,11 @@ class StreamSelectDriverTest extends DriverTest
             // win FD_SETSIZE not 1024
             self::markTestSkipped('Skip on Windows');
         }
+
         $sockets = [];
-        $domain = \stripos(PHP_OS, 'win') === 0 ? STREAM_PF_INET : STREAM_PF_UNIX;
 
         for ($i = 0; $i < 1001; $i++) {
-            $sockets[] = \stream_socket_pair($domain, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+            $sockets[] = \stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
         }
 
         $this->expectException(\Exception::class);


### PR DESCRIPTION
windows FD_SETSIZE different from linux

https://learn.microsoft.com/en-us/windows/win32/winsock/maximum-number-of-sockets-supported-2