### PR TITLE
Fix Fiber leaks if Suspension never resumed

### DIFF
--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -285,12 +285,21 @@ abstract class AbstractDriver implements Driver
         \assert($fiber !== $this->fiber);
 
         // Use current object in case of {main}
-        return $this->suspensions[$fiber ?? $this] ??= new DriverSuspension(
+        if (isset($this->suspensions[$fiber ?? $this])) {
+            if ($suspension = $this->suspensions[$fiber ?? $this]->get()) {
+                return $suspension;
+            }
+        }
+
+        $suspension = new DriverSuspension(
             $this->runCallback,
             $this->queueCallback,
             $this->interruptCallback,
             $this->suspensions
         );
+        $this->suspensions[$fiber ?? $this] = \WeakReference::create($suspension);
+
+        return $suspension;
     }
 
     public function setErrorHandler(?\Closure $errorHandler): void

--- a/src/EventLoop/Internal/DriverSuspension.php
+++ b/src/EventLoop/Internal/DriverSuspension.php
@@ -104,17 +104,17 @@ final class DriverSuspension implements Suspension
             $info = '';
             $suspensions = $this->suspensions->get();
             if ($suspensions) {
-                \gc_collect_cycles();
-
-                /** @var self $suspension */
-                foreach ($suspensions as $suspension) {
-                    $fiber = $suspension->fiberRef?->get();
-                    if ($fiber === null) {
-                        continue;
+                foreach ($suspensions as $suspensionRef) {
+                    /** @var self $suspension */
+                    if ($suspension = $suspensionRef->get()) {
+                        $fiber = $suspension->fiberRef?->get();
+                        if ($fiber === null) {
+                            continue;
+                        }
+    
+                        $reflectionFiber = new \ReflectionFiber($fiber);
+                        $info .= "\n\n" . $this->formatStacktrace($reflectionFiber->getTrace(\DEBUG_BACKTRACE_IGNORE_ARGS));
                     }
-
-                    $reflectionFiber = new \ReflectionFiber($fiber);
-                    $info .= "\n\n" . $this->formatStacktrace($reflectionFiber->getTrace(\DEBUG_BACKTRACE_IGNORE_ARGS));
                 }
             }
 

--- a/src/EventLoop/Internal/DriverSuspension.php
+++ b/src/EventLoop/Internal/DriverSuspension.php
@@ -111,7 +111,7 @@ final class DriverSuspension implements Suspension
                         if ($fiber === null) {
                             continue;
                         }
-    
+
                         $reflectionFiber = new \ReflectionFiber($fiber);
                         $info .= "\n\n" . $this->formatStacktrace($reflectionFiber->getTrace(\DEBUG_BACKTRACE_IGNORE_ARGS));
                     }

--- a/test/EventLoopTest.php
+++ b/test/EventLoopTest.php
@@ -269,8 +269,7 @@ class EventLoopTest extends TestCase
 
         \gc_collect_cycles();
 
-        // This documents an expected failure, should actually be true, but suspensions have to be resumed currently.
-        self::assertNull($finally);
+        self::assertTrue($finally);
     }
 
     public function testSuspensionWithinQueue(): void


### PR DESCRIPTION
Have a circular reference between the weak map of key and value.

It splits the circular reference of key and value.

Now, the Fiber with `Suspension` object, so if the object is not keep, garbage collected will occur at the next Fiber `suspend` .

related https://github.com/revoltphp/event-loop/pull/52#issuecomment-1042396714.