### PR TITLE
Remove Suspension cache to avoid memory leak

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -28,6 +28,7 @@ final class Config extends PhpCsFixerConfig
                 "allow_single_line_closure" => true,
             ],
             "array_syntax" => ["syntax" => "short"],
+            "blank_lines_before_namespace" => true,
             "cast_spaces" => true,
             "combine_consecutive_unsets" => true,
             "declare_strict_types" => true,
@@ -73,7 +74,6 @@ final class Config extends PhpCsFixerConfig
             "psr_autoloading" => ['dir' => $this->src],
             "return_type_declaration" => ["space_before" => "none"],
             "short_scalar_cast" => true,
-            "single_blank_line_before_namespace" => true,
             "line_ending" => true,
         ];
     }

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -61,12 +61,8 @@ abstract class AbstractDriver implements Driver
     private bool $idle = false;
     private bool $stopped = false;
 
-    private \WeakMap $suspensions;
-
     public function __construct()
     {
-        $this->suspensions = new \WeakMap();
-
         $this->internalSuspensionMarker = new \stdClass();
         $this->microtaskQueue = new \SplQueue();
         $this->callbackQueue = new \SplQueue();
@@ -284,12 +280,10 @@ abstract class AbstractDriver implements Driver
         // User callbacks are always executed outside the event loop fiber, so this should always be false.
         \assert($fiber !== $this->fiber);
 
-        // Use current object in case of {main}
-        return $this->suspensions[$fiber ?? $this] ??= new DriverSuspension(
+        return new DriverSuspension(
             $this->runCallback,
             $this->queueCallback,
             $this->interruptCallback,
-            $this->suspensions
         );
     }
 

--- a/src/EventLoop/Internal/DriverSuspension.php
+++ b/src/EventLoop/Internal/DriverSuspension.php
@@ -97,7 +97,15 @@ final class DriverSuspension implements Suspension
             $this->pending = false;
             $result && $result(); // Unwrap any uncaught exceptions from the event loop
 
-            throw new \Error('Event loop terminated without resuming the current suspension');
+            $message = 'Event loop terminated without resuming the current suspension';
+
+            $fiber = $this->fiberRef?->get();
+            if ($fiber) {
+                $reflectionFiber = new \ReflectionFiber($fiber);
+                $message .= "\n\n" . $this->formatStacktrace($reflectionFiber->getTrace(\DEBUG_BACKTRACE_IGNORE_ARGS));
+            }
+
+            throw new \Error($message);
         }
 
         return $result();

--- a/test/EventLoopTest.php
+++ b/test/EventLoopTest.php
@@ -269,8 +269,7 @@ class EventLoopTest extends TestCase
 
         \gc_collect_cycles();
 
-        // This documents an expected failure, should actually be true, but suspensions have to be resumed currently.
-        self::assertNull($finally);
+        self::assertTrue($finally);
     }
 
     public function testSuspensionWithinQueue(): void


### PR DESCRIPTION
This removes the `Suspension` cache in `AbstractDriver` to avoid leaking memory if a fiber is never resumed. While this will cause a slight performance decrease, avoiding memory leaks from non-resumed fibers is a reasonable trade-off.