### PR TITLE
Fix Fiber leaks if Suspension never resumed, v2

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -28,6 +28,7 @@ final class Config extends PhpCsFixerConfig
                 "allow_single_line_closure" => true,
             ],
             "array_syntax" => ["syntax" => "short"],
+            "blank_lines_before_namespace" => true,
             "cast_spaces" => true,
             "combine_consecutive_unsets" => true,
             "declare_strict_types" => true,
@@ -73,7 +74,6 @@ final class Config extends PhpCsFixerConfig
             "psr_autoloading" => ['dir' => $this->src],
             "return_type_declaration" => ["space_before" => "none"],
             "short_scalar_cast" => true,
-            "single_blank_line_before_namespace" => true,
             "line_ending" => true,
         ];
     }

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -285,12 +285,21 @@ abstract class AbstractDriver implements Driver
         \assert($fiber !== $this->fiber);
 
         // Use current object in case of {main}
-        return $this->suspensions[$fiber ?? $this] ??= new DriverSuspension(
+        if (isset($this->suspensions[$fiber ?? $this])) {
+            if ($suspension = $this->suspensions[$fiber ?? $this]->get()) {
+                return $suspension;
+            }
+        }
+
+        $suspension = new DriverSuspension(
             $this->runCallback,
             $this->queueCallback,
             $this->interruptCallback,
             $this->suspensions
         );
+        $this->suspensions[$fiber ?? $this] = \WeakReference::create($suspension);
+
+        return $suspension;
     }
 
     public function setErrorHandler(?\Closure $errorHandler): void

--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -285,18 +285,18 @@ abstract class AbstractDriver implements Driver
         \assert($fiber !== $this->fiber);
 
         // Use current object in case of {main}
-        if (isset($this->suspensions[$fiber ?? $this])) {
-            if ($suspension = $this->suspensions[$fiber ?? $this]->get()) {
-                return $suspension;
-            }
+        $suspension = ($this->suspensions[$fiber ?? $this] ?? null)?->get();
+        if ($suspension) {
+            return $suspension;
         }
 
         $suspension = new DriverSuspension(
             $this->runCallback,
             $this->queueCallback,
             $this->interruptCallback,
-            $this->suspensions
+            $this->suspensions,
         );
+
         $this->suspensions[$fiber ?? $this] = \WeakReference::create($suspension);
 
         return $suspension;

--- a/src/EventLoop/Internal/DriverSuspension.php
+++ b/src/EventLoop/Internal/DriverSuspension.php
@@ -91,6 +91,8 @@ final class DriverSuspension implements Suspension
             $this->pending = false;
             $result && $result(); // Unwrap any uncaught exceptions from the event loop
 
+            \gc_collect_cycles(); // Collect any circular references before dumping pending suspensions.
+
             $info = '';
             foreach ($this->suspensions as $suspensionRef) {
                 if ($suspension = $suspensionRef->get()) {

--- a/src/EventLoop/Internal/DriverSuspension.php
+++ b/src/EventLoop/Internal/DriverSuspension.php
@@ -104,17 +104,17 @@ final class DriverSuspension implements Suspension
             $info = '';
             $suspensions = $this->suspensions->get();
             if ($suspensions) {
-                \gc_collect_cycles();
-
-                /** @var self $suspension */
-                foreach ($suspensions as $suspension) {
-                    $fiber = $suspension->fiberRef?->get();
-                    if ($fiber === null) {
-                        continue;
+                foreach ($suspensions as $suspensionRef) {
+                    /** @var self $suspension */
+                    if ($suspension = $suspensionRef->get()) {
+                        $fiber = $suspension->fiberRef?->get();
+                        if ($fiber === null) {
+                            continue;
+                        }
+    
+                        $reflectionFiber = new \ReflectionFiber($fiber);
+                        $info .= "\n\n" . $this->formatStacktrace($reflectionFiber->getTrace(\DEBUG_BACKTRACE_IGNORE_ARGS));
                     }
-
-                    $reflectionFiber = new \ReflectionFiber($fiber);
-                    $info .= "\n\n" . $this->formatStacktrace($reflectionFiber->getTrace(\DEBUG_BACKTRACE_IGNORE_ARGS));
                 }
             }
 

--- a/src/EventLoop/Internal/DriverSuspension.php
+++ b/src/EventLoop/Internal/DriverSuspension.php
@@ -111,7 +111,7 @@ final class DriverSuspension implements Suspension
                         if ($fiber === null) {
                             continue;
                         }
-    
+
                         $reflectionFiber = new \ReflectionFiber($fiber);
                         $info .= "\n\n" . $this->formatStacktrace($reflectionFiber->getTrace(\DEBUG_BACKTRACE_IGNORE_ARGS));
                     }

--- a/test/EventLoopTest.php
+++ b/test/EventLoopTest.php
@@ -269,8 +269,7 @@ class EventLoopTest extends TestCase
 
         \gc_collect_cycles();
 
-        // This documents an expected failure, should actually be true, but suspensions have to be resumed currently.
-        self::assertNull($finally);
+        self::assertTrue($finally);
     }
 
     public function testSuspensionWithinQueue(): void


### PR DESCRIPTION
This PR builds upon #75, removing the weak reference in `DriverSuspension` since it is no longer necessary as the entire map contains only weak references. This then supersedes #78 so we can retain the dump of stack traces of active suspensions.