### PR TITLE
Check if fiber was destroyed before resuming

### DIFF
--- a/src/EventLoop/Internal/DriverSuspension.php
+++ b/src/EventLoop/Internal/DriverSuspension.php
@@ -1,4 +1,6 @@
-<?php /** @noinspection PhpPropertyOnlyWrittenInspection */
+<?php
+
+/** @noinspection PhpPropertyOnlyWrittenInspection */
 
 declare(strict_types=1);
 

--- a/src/EventLoop/Internal/DriverSuspension.php
+++ b/src/EventLoop/Internal/DriverSuspension.php
@@ -79,15 +79,17 @@ final class DriverSuspension implements Suspension
             $this->suspendedFiber = $fiber;
 
             try {
-                return \Fiber::suspend();
+                $value = \Fiber::suspend();
+                $this->suspendedFiber = null;
             } catch (\FiberError $exception) {
                 $this->pending = false;
+                $this->suspendedFiber = null;
                 $this->fiberError = $exception;
 
                 throw $exception;
-            } finally {
-                $this->suspendedFiber = null;
             }
+
+            return $value;
         }
 
         // Awaiting from {main}.

--- a/src/EventLoop/Internal/DriverSuspension.php
+++ b/src/EventLoop/Internal/DriverSuspension.php
@@ -89,6 +89,9 @@ final class DriverSuspension implements Suspension
                 throw $exception;
             }
 
+            // Setting $this->suspendedFiber = null in finally will set the fiber to null if a fiber is destroyed
+            // as part of a cycle collection, causing an error if the suspension is subsequently resumed.
+
             return $value;
         }
 

--- a/test/EventLoopTest.php
+++ b/test/EventLoopTest.php
@@ -311,7 +311,8 @@ class EventLoopTest extends TestCase
             {
             }
 
-            public function suspend(): void {
+            public function suspend(): void
+            {
                 $this->suspension = EventLoop::getSuspension();
                 $this->suspension->suspend();
             }

--- a/test/EventLoopTest.php
+++ b/test/EventLoopTest.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Revolt\EventLoop;
 
-use Ev;
 use PHPUnit\Framework\TestCase;
 use Revolt\EventLoop;
-use Symfony\Contracts\EventDispatcher\Event;
 
 class EventLoopTest extends TestCase
 {


### PR DESCRIPTION
Since fixing the hard reference retained to suspensions in the event loop, the cycle collector may collect an object holding a `DriverSuspension`, the `DriverSuspension` itself, and the suspended `Fiber`, queuing them for destruction. Once queued for destruction, all destructors are invoked. If the object holding the suspension queues the fiber to be resumed, the fiber destructor is run and the fiber terminated before it can be resumed.

This PR adds a check if the fiber has been destroyed while the fiber was queued to be resumed. I believe the fiber can only be destroyed while being queued for resuming after a call to `gc_collect_cycles` or if the cycle collector is automatically triggered.

The only alternative seems to be to retain a hard reference to the fiber elsewhere, but this would again cause any non-resumed fiber to leak because the fiber reference would remain in the list of hard references.