### PR TITLE
Ignore spurious resumes on {main} suspension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "ext-json": "*",
         "phpunit/phpunit": "^9",
         "jetbrains/phpstorm-stubs": "^2019.3",
-        "psalm/phar": "^4.7"
+        "psalm/phar": "^5"
     },
     "autoload": {
         "psr-4": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
+  <file src="src/EventLoop/Driver/EvDriver.php">
+    <UnsupportedPropertyReferenceUsage>
+      <code><![CDATA[self::$activeSignals = &$this->signals]]></code>
+      <code><![CDATA[self::$activeSignals = &$this->signals]]></code>
+    </UnsupportedPropertyReferenceUsage>
+  </file>
+  <file src="src/EventLoop/Driver/EventDriver.php">
+    <UnsupportedPropertyReferenceUsage>
+      <code><![CDATA[self::$activeSignals = &$this->signals]]></code>
+      <code><![CDATA[self::$activeSignals = &$this->signals]]></code>
+    </UnsupportedPropertyReferenceUsage>
+  </file>
+  <file src="src/EventLoop/Driver/StreamSelectDriver.php">
+    <RedundantCast>
+      <code>(int) ($timeout * 1_000_000)</code>
+    </RedundantCast>
+  </file>
+  <file src="src/EventLoop/Driver/TracingDriver.php">
+    <InvalidArgument>
+      <code>\debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS)</code>
+      <code>\debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS)</code>
+      <code>\debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS)</code>
+      <code>\debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS)</code>
+      <code>\debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS)</code>
+      <code>\debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS)</code>
+      <code>\debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS)</code>
+    </InvalidArgument>
+  </file>
+  <file src="src/EventLoop/Driver/UvDriver.php">
+    <UndefinedFunction>
+      <code><![CDATA[\uv_poll_init_socket($this->handle, $callback->stream)]]></code>
+      <code><![CDATA[\uv_signal_init($this->handle)]]></code>
+      <code><![CDATA[\uv_signal_start($event, $this->signalCallback, $callback->signal)]]></code>
+    </UndefinedFunction>
+  </file>
+  <file src="src/EventLoop/Internal/AbstractDriver.php">
+    <RedundantCondition>
+      <code><![CDATA[!$this->stopped]]></code>
+    </RedundantCondition>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,6 +5,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="https://getpsalm.org/schema/config"
         xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+        errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="examples"/>

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -346,7 +346,7 @@ final class EventLoop
      *
      * @param string $callbackId The callback identifier.
      *
-     * @return bool {@code true} if the callback is currently enabled, otherwise {@code false}.
+     * @return bool `true` if the callback is currently enabled, otherwise `false`.
      */
     public static function isEnabled(string $callbackId): bool
     {
@@ -358,7 +358,7 @@ final class EventLoop
      *
      * @param string $callbackId The callback identifier.
      *
-     * @return bool {@code true} if the callback is currently referenced, otherwise {@code false}.
+     * @return bool `true` if the callback is currently referenced, otherwise `false`.
      */
     public static function isReferenced(string $callbackId): bool
     {

--- a/src/EventLoop/Driver.php
+++ b/src/EventLoop/Driver.php
@@ -294,7 +294,7 @@ interface Driver
      *
      * @param string $callbackId The callback identifier.
      *
-     * @return bool {@code true} if the callback is currently enabled, otherwise {@code false}.
+     * @return bool `true` if the callback is currently enabled, otherwise `false`.
      */
     public function isEnabled(string $callbackId): bool;
 
@@ -303,7 +303,7 @@ interface Driver
      *
      * @param string $callbackId The callback identifier.
      *
-     * @return bool {@code true} if the callback is currently referenced, otherwise {@code false}.
+     * @return bool `true` if the callback is currently referenced, otherwise `false`.
      */
     public function isReferenced(string $callbackId): bool;
 

--- a/src/EventLoop/Internal/DriverSuspension.php
+++ b/src/EventLoop/Internal/DriverSuspension.php
@@ -71,6 +71,7 @@ final class DriverSuspension implements Suspension
     {
         // Throw exception when trying to use old dead {main} suspension
         if ($this->deadMain) {
+            \assert($this->error !== null);
             throw $this->error;
         }
         if ($this->pending) {

--- a/test/EventLoopTest.php
+++ b/test/EventLoopTest.php
@@ -299,17 +299,49 @@ class EventLoopTest extends TestCase
             self::assertSame($error, $t->getPrevious());
         }
 
+        $suspension->resume(); // Calling resume on the same suspension should not throw an Error.
+        $suspension->throw(new \RuntimeException()); // Calling throw on the same suspension should not throw an Error.
+
         try {
-            $suspension->resume(); // Calling resume on the same suspension should throw an Error.
+            $suspension->suspend(); // Calling suspend on the same suspension should throw an Error.
             self::fail("Error was not thrown");
         } catch (\Error $e) {
-            self::assertStringContainsString('resumed after an uncaught exception', $e->getMessage());
+            self::assertStringContainsString('suspended after an uncaught exception', $e->getMessage());
         }
 
         // Creating a new Suspension and re-entering the event loop (e.g. in a shutdown function) should work.
         $suspension = EventLoop::getSuspension();
         EventLoop::queue($suspension->resume(...));
         $suspension->suspend();
+    }
+
+    public function testSuspensionThrowingErrorViaInterrupt2(): void
+    {
+        $suspension = EventLoop::getSuspension();
+        $error = new \Error("Test error");
+        EventLoop::queue(static fn () => throw $error);
+        EventLoop::queue($suspension->resume(...), 123);
+        try {
+            $suspension->suspend();
+            self::fail("Error was not thrown");
+        } catch (UncaughtThrowable $t) {
+            self::assertSame($error, $t->getPrevious());
+        }
+
+        $suspension->resume(); // Calling resume on the same suspension should not throw an Error.
+        $suspension->throw(new \RuntimeException()); // Calling throw on the same suspension should not throw an Error.
+
+        try {
+            $suspension->suspend(); // Calling suspend on the same suspension should throw an Error.
+            self::fail("Error was not thrown");
+        } catch (\Error $e) {
+            self::assertStringContainsString('suspended after an uncaught exception', $e->getMessage());
+        }
+
+        // Creating a new Suspension and re-entering the event loop (e.g. in a shutdown function) should work.
+        $suspension = EventLoop::getSuspension();
+        EventLoop::queue($suspension->resume(...), 321);
+        $this->assertEquals(321, $suspension->suspend());
     }
 
     public function testFiberDestroyedWhileSuspended(): void


### PR DESCRIPTION
Avoids issues with this reproducer:

```php
<?php

use Amp\DeferredFuture;
use Revolt\EventLoop;

require 'vendor/autoload.php';

$f = new DeferredFuture;

EventLoop::queue(fn () => throw new \Error());
EventLoop::queue($f->complete(...), "Not an integer");

try {
    var_dump($f->getFuture()->await());
} catch (\Throwable) {}

function test(): int {
    $f2 = new DeferredFuture;
    EventLoop::queue($f2->complete(...), 321);
    return $f2->getFuture()->await();
}

var_dump(test());
```