### PR TITLE
Allow queueing of callbacks in destructors

### DIFF
--- a/src/EventLoop/Internal/AbstractDriver.php
+++ b/src/EventLoop/Internal/AbstractDriver.php
@@ -558,7 +558,7 @@ abstract class AbstractDriver implements Driver
                 $this->idle = true;
 
                 $this->tick($previousIdle);
-                $didWork = $this->invokeCallbacks();
+                $didWork = $this->invokeCallbacks() || $didWork;
             }
 
             return $didWork;

--- a/src/EventLoop/Internal/DriverSuspension.php
+++ b/src/EventLoop/Internal/DriverSuspension.php
@@ -28,7 +28,7 @@ final class DriverSuspension implements Suspension
     private bool $deadMain = false;
 
     /**
-     * @param \Closure(): (?\Closure(): mixed) $run
+     * @param \Closure(): ((\Closure(): mixed)|bool|null) $run
      * @param \WeakMap<object, \WeakReference<DriverSuspension>> $suspensions
      */
     public function __construct(
@@ -116,6 +116,10 @@ final class DriverSuspension implements Suspension
 
         // Awaiting from {main}.
         $result = ($this->run)();
+
+        while ($this->pending && $result === false) {
+
+        }
 
         /** @psalm-suppress RedundantCondition $this->pending should be changed when resumed. */
         if ($this->pending) {

--- a/src/EventLoop/Internal/DriverSuspension.php
+++ b/src/EventLoop/Internal/DriverSuspension.php
@@ -28,7 +28,7 @@ final class DriverSuspension implements Suspension
     private bool $deadMain = false;
 
     /**
-     * @param \Closure(): ((\Closure(): mixed)|bool|null) $run
+     * @param \Closure(): ((\Closure(): mixed)|bool) $run
      * @param \WeakMap<object, \WeakReference<DriverSuspension>> $suspensions
      */
     public function __construct(
@@ -117,8 +117,11 @@ final class DriverSuspension implements Suspension
         // Awaiting from {main}.
         $result = ($this->run)();
 
-        while ($this->pending && $result === false) {
-
+        if ($this->pending && \is_bool($result)) {
+            do {
+                while (\gc_collect_cycles());
+                $result = ($this->run)();
+            } while ($this->pending && $result === true);
         }
 
         /** @psalm-suppress RedundantCondition $this->pending should be changed when resumed. */

--- a/src/EventLoop/Internal/DriverSuspension.php
+++ b/src/EventLoop/Internal/DriverSuspension.php
@@ -28,6 +28,7 @@ final class DriverSuspension implements Suspension
     private bool $deadMain = false;
 
     /**
+     * @param \Closure(): (?\Closure(): mixed) $run
      * @param \WeakMap<object, \WeakReference<DriverSuspension>> $suspensions
      */
     public function __construct(
@@ -145,6 +146,7 @@ final class DriverSuspension implements Suspension
             throw new \Error('Event loop terminated without resuming the current suspension (the cause is either a fiber deadlock, or an incorrectly unreferenced/canceled watcher):' . $info);
         }
 
+        \assert($result !== null);
         return $result();
     }
 


### PR DESCRIPTION
Fixes https://github.com/revoltphp/event-loop/issues/90.

Possibly the root cause of fiber deadlocks at work as well.