### PR TITLE
Register shutdown function to clear event loop

### DIFF
--- a/examples/shutdown.php
+++ b/examples/shutdown.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Revolt\EventLoop;
+
+\register_shutdown_function(function (): void {
+    \register_shutdown_function(function (): void {
+        EventLoop::defer(function (): void {
+            print 'Shutdown function registered within pre-loop-run shutdown function' . PHP_EOL;
+        });
+    });
+
+
+    EventLoop::defer(function (): void {
+        print 'Shutdown function registered before EventLoop::run()' . PHP_EOL;
+    });
+});
+
+EventLoop::run();
+
+\register_shutdown_function(function (): void {
+    \register_shutdown_function(function (): void {
+        EventLoop::defer(function (): void {
+            print 'Shutdown function registered within post-loop-run shutdown function' . PHP_EOL;
+        });
+    });
+
+    EventLoop::defer(function (): void {
+        print 'Shutdown function registered after EventLoop::run()' . PHP_EOL;
+    });
+});
+
+print 'End of script' . PHP_EOL;

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -73,6 +73,8 @@ final class EventLoop
 
     private static function onShutdown(int $invocationCount): void
     {
+        \gc_collect_cycles();
+
         $driver = self::getDriver();
 
         $pending = false;


### PR DESCRIPTION
This repeatedly registers shutdown functions which run the event loop until a function does not discover any additional enabled and referenced callbacks in the event loop. The first invocation of the shutdown function always registers another invocation so that any shutdown functions registered during script execution are executed before the second invocation.

There are edge cases where a shutdown function registering another shutdown function which then adds callbacks to the event loop may not be executed, but I consider those cases highly unlikely. I think this will cover every practical use case to avoid unexecuted events on script termination.

Testing shutdown functions in unit tests is difficult, so I added an example which demonstrates the new shutdown behavior.